### PR TITLE
Use unmock on device in development

### DIFF
--- a/__tests__/App.test.tsx
+++ b/__tests__/App.test.tsx
@@ -1,6 +1,6 @@
 import 'react-native';
 import React from 'react';
-import App, {CAT_FACT_PATH, CAT_FACT_API_URL} from '../src/App';
+import App, {CAT_FACT_PATH, CAT_FACT_API_URL, unmockOn} from '../src/App';
 
 import unmock, {transform, u} from 'unmock';
 
@@ -17,12 +17,7 @@ global.fetch = require('node-fetch');
 
 describe('App', () => {
   beforeAll(() => {
-    unmock.on();
-    unmock
-      .nock(CAT_FACT_API_URL, 'catFactApi')
-      .get(CAT_FACT_PATH)
-      .reply(200, {text: u.string('lorem.sentence')})
-      .reply(500, 'Internal server error');
+    unmockOn(unmock);
   });
   beforeEach(() => {
     unmock.reset();

--- a/__tests__/App.test.tsx
+++ b/__tests__/App.test.tsx
@@ -1,6 +1,6 @@
 import 'react-native';
 import React from 'react';
-import App, {CAT_FACT_PATH, CAT_FACT_API_URL, unmockOn} from '../src/App';
+import App, {mockCatFactAPI} from '../src/App';
 
 import unmock, {transform, u} from 'unmock';
 
@@ -17,7 +17,7 @@ global.fetch = require('node-fetch');
 
 describe('App', () => {
   beforeAll(() => {
-    unmockOn(unmock);
+    mockCatFactAPI(unmock);
   });
   beforeEach(() => {
     unmock.reset();

--- a/__tests__/App.test.tsx
+++ b/__tests__/App.test.tsx
@@ -1,6 +1,6 @@
 import 'react-native';
 import React from 'react';
-import App from '../src/App';
+import App, {CAT_FACT_PATH, CAT_FACT_API_URL} from '../src/App';
 
 import unmock, {transform, u} from 'unmock';
 
@@ -15,14 +15,12 @@ import {
 // @ts-ignore
 global.fetch = require('node-fetch');
 
-// https://cat-fact.herokuapp.com/facts/random?animal_type=cat&amount=1
-
 describe('App', () => {
   beforeAll(() => {
     unmock.on();
     unmock
-      .nock('https://cat-fact.herokuapp.com', 'catFactApi')
-      .get('/facts/random?animal_type=cat&amount=1')
+      .nock(CAT_FACT_API_URL, 'catFactApi')
+      .get(CAT_FACT_PATH)
       .reply(200, {text: u.string('lorem.sentence')})
       .reply(500, 'Internal server error');
   });

--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
     "buffer": "^5.4.3",
     "react": "16.9.0",
     "react-native": "0.61.2",
-    "unmock": "file:../unmock-js/packages/unmock",
-    "url": "^0.11.0"
+    "unmock": "file:../unmock-js/packages/unmock"
   },
   "devDependencies": {
     "@babel/core": "^7.6.3",

--- a/package.json
+++ b/package.json
@@ -10,9 +10,11 @@
     "lint": "eslint ."
   },
   "dependencies": {
+    "buffer": "^5.4.3",
     "react": "16.9.0",
     "react-native": "0.61.2",
-    "unmock": "file:../unmock-js/packages/unmock"
+    "unmock": "file:../unmock-js/packages/unmock",
+    "url": "^0.11.0"
   },
   "devDependencies": {
     "@babel/core": "^7.6.3",
@@ -27,8 +29,7 @@
     "metro-react-native-babel-preset": "^0.56.0",
     "node-fetch": "^2.6.0",
     "react-native-testing-library": "^1.11.1",
-    "react-test-renderer": "16.9.0",
-    "unmock": "^0.3.8"
+    "react-test-renderer": "16.9.0"
   },
   "jest": {
     "preset": "react-native",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "buffer": "^5.4.3",
     "react": "16.9.0",
     "react-native": "0.61.2",
     "unmock": "file:../unmock-js/packages/unmock"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "react": "16.9.0",
     "react-native": "0.61.2",
-    "unmock-react-native": "file:../unmock-js/packages/unmock-react-native"
+    "unmock": "file:../unmock-js/packages/unmock"
   },
   "devDependencies": {
     "@babel/core": "^7.6.3",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "react": "16.9.0",
-    "react-native": "0.61.2"
+    "react-native": "0.61.2",
+    "unmock-react-native": "file:../unmock-js/packages/unmock-react-native"
   },
   "devDependencies": {
     "@babel/core": "^7.6.3",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "react": "16.9.0",
     "react-native": "0.61.2",
-    "unmock": "file:../unmock-js/packages/unmock"
+    "unmock": "^0.3.11"
   },
   "devDependencies": {
     "@babel/core": "^7.6.3",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,25 +2,25 @@ import React, {useState, useEffect} from 'react';
 import {Button, StyleSheet, View, Text} from 'react-native';
 import {Colors} from 'react-native/Libraries/NewAppScreen';
 import unmock from 'unmock-browser';
-import {u} from 'unmock';
+import {u, UnmockPackage} from 'unmock';
 
 const useUnmock = process.env.NODE_ENV === 'development';
 
 export const CAT_FACT_API_URL = 'https://cat-fact.herokuapp.com';
 export const CAT_FACT_PATH = '/facts/random?animal_type=cat&amount=1';
 
-const unmockOn = () => {
+export const unmockOn = (unmock: UnmockPackage) => {
   unmock.on();
 
   unmock
-    .nock(CAT_FACT_API_URL)
+    .nock(CAT_FACT_API_URL, 'catFactApi')
     .get(CAT_FACT_PATH)
     .reply(200, {text: u.string('lorem.sentence')})
     .reply(500, 'Internal server error');
 };
 
 if (useUnmock) {
-  unmockOn();
+  unmockOn(unmock);
 }
 
 const fetchFact = async () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,25 +2,29 @@ import React, {useState, useEffect} from 'react';
 import {Button, StyleSheet, View, Text} from 'react-native';
 import {Colors} from 'react-native/Libraries/NewAppScreen';
 import unmock from 'unmock-browser';
-import { u } from "unmock";
-// import {buildFetch} from 'unmock-fetch';
+import {u} from 'unmock';
 
-unmock.on();
+const useUnmock = process.env.NODE_ENV === 'development';
 
-// const faker = unmock.newFaker();
+export const CAT_FACT_API_URL = 'https://cat-fact.herokuapp.com';
+export const CAT_FACT_PATH = '/facts/random?animal_type=cat&amount=1';
 
-unmock
-  .nock('https://cat-fact.herokuapp.com')
-  .get('/facts/random?animal_type=cat&amount=1')
-  .reply(200, {text: u.string('lorem.sentence')})
-  .reply(500, 'Internal server error');
+const unmockOn = () => {
+  unmock.on();
 
-// const fetch = buildFetch(faker.createResponse.bind(faker));
+  unmock
+    .nock(CAT_FACT_API_URL)
+    .get(CAT_FACT_PATH)
+    .reply(200, {text: u.string('lorem.sentence')})
+    .reply(500, 'Internal server error');
+};
 
-const CAT_FACT_URL =
-  'https://cat-fact.herokuapp.com/facts/random?animal_type=cat&amount=1';
+if (useUnmock) {
+  unmockOn();
+}
 
 const fetchFact = async () => {
+  const CAT_FACT_URL = `${CAT_FACT_API_URL}${CAT_FACT_PATH}`;
   const fetchResult = await fetch(CAT_FACT_URL);
   if (!fetchResult.ok) {
     throw Error(`Failed fetching cat fact with code: ${fetchResult.status}`);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,7 +44,7 @@ const App = () => {
       setError(null);
       console.log(`Set fact: ${fact}`);
     } catch (err) {
-      // console.error(`Failed fetching fact: ${err.message}`);
+      console.log(`Failed fetching fact: ${err.message}`);
       setError(err);
     } finally {
       setLoading(false);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,20 +1,31 @@
 import React, {useState, useEffect} from 'react';
 import {Button, StyleSheet, View, Text} from 'react-native';
 import {Colors} from 'react-native/Libraries/NewAppScreen';
+import unmock from 'unmock-react-native';
+
+const useUnmock = true;
 
 const CAT_FACT_URL =
   'https://cat-fact.herokuapp.com/facts/random?animal_type=cat&amount=1';
 
 const fetchFact = async () => {
   console.log(`Fetching new cat fact`);
-  const fetchResult = await fetch(CAT_FACT_URL);
-  if (!fetchResult.ok) {
-    throw Error(`Failed fetching cat fact with code: ${fetchResult.status}`);
+  if (useUnmock) {
+    unmock.on();
+    console.log(`Unmock on`);
   }
-  const body = await fetchResult.json();
-  const fact = body.text;
-  console.log(`Got a new fact: ${fact}`);
-  return fact;
+  try {
+    const fetchResult = await fetch(CAT_FACT_URL);
+    if (!fetchResult.ok) {
+      throw Error(`Failed fetching cat fact with code: ${fetchResult.status}`);
+    }
+    const body = await fetchResult.json();
+    const fact = body.text;
+    console.log(`Got a new fact: ${fact}`);
+    return fact;
+  } finally {
+    unmock.off();
+  }
 };
 
 const App = () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,8 +2,21 @@ import React, {useState, useEffect} from 'react';
 import {Button, StyleSheet, View, Text} from 'react-native';
 import {Colors} from 'react-native/Libraries/NewAppScreen';
 import unmock, {u} from 'unmock';
+import {buildFetch} from 'unmock-fetch';
+
+if (typeof Buffer === 'undefined') global.Buffer = require('buffer').Buffer;
 
 const useUnmock = true;
+
+const faker = unmock.newFaker();
+
+faker
+  .nock('https://cat-fact.herokuapp.com')
+  .get('/facts/random?animal_type=cat&amount=1')
+  .reply(200, {text: 'Fake fact from unmock'})
+  .reply(500, 'Internal server error');
+
+const fetch = buildFetch(faker.createResponse.bind(faker));
 
 const CAT_FACT_URL =
   'https://cat-fact.herokuapp.com/facts/random?animal_type=cat&amount=1';
@@ -19,15 +32,15 @@ const unmockOn = () => {
 };
 
 const fetchFact = async () => {
-  console.log(`Fetching new cat fact`);
-  if (useUnmock) {
+  // console.log(`Fetching new cat fact`);
+  /* if (useUnmock) {
     unmock.on();
     unmock
       .nock('https://cat-fact.herokuapp.com')
       .get('/facts/random?animal_type=cat&amount=1')
       .reply(200, {text: 'Fake fact from unmock'});
-    console.log(`Unmock on`);
-  }
+    // console.log(`Unmock on`);
+  } */
   try {
     const fetchResult = await fetch(CAT_FACT_URL);
     if (!fetchResult.ok) {
@@ -35,7 +48,7 @@ const fetchFact = async () => {
     }
     const body = await fetchResult.json();
     const fact = body.text;
-    console.log(`Got a new fact: ${fact}`);
+    // console.log(`Got a new fact: ${fact}`);
     return fact;
   } finally {
     unmock.off();
@@ -54,7 +67,7 @@ const App = () => {
       setError(null);
       console.log(`Set fact: ${fact}`);
     } catch (err) {
-      console.error(`Failed fetching fact: ${err.message}`);
+      // console.error(`Failed fetching fact: ${err.message}`);
       setError(err);
     } finally {
       setLoading(false);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,35 +1,34 @@
 import React, {useState, useEffect} from 'react';
 import {Button, StyleSheet, View, Text} from 'react-native';
 import {Colors} from 'react-native/Libraries/NewAppScreen';
-import unmock, {u} from 'unmock';
-import {buildFetch} from 'unmock-fetch';
+import unmock from 'unmock-browser';
+import { u } from "unmock";
+// import {buildFetch} from 'unmock-fetch';
 
-const faker = unmock.newFaker();
+unmock.on();
 
-faker
+// const faker = unmock.newFaker();
+
+unmock
   .nock('https://cat-fact.herokuapp.com')
   .get('/facts/random?animal_type=cat&amount=1')
   .reply(200, {text: u.string('lorem.sentence')})
   .reply(500, 'Internal server error');
 
-const fetch = buildFetch(faker.createResponse.bind(faker));
+// const fetch = buildFetch(faker.createResponse.bind(faker));
 
 const CAT_FACT_URL =
   'https://cat-fact.herokuapp.com/facts/random?animal_type=cat&amount=1';
 
 const fetchFact = async () => {
-  try {
-    const fetchResult = await fetch(CAT_FACT_URL);
-    if (!fetchResult.ok) {
-      throw Error(`Failed fetching cat fact with code: ${fetchResult.status}`);
-    }
-    const body = await fetchResult.json();
-    const fact = body.text;
-    // console.log(`Got a new fact: ${fact}`);
-    return fact;
-  } finally {
-    unmock.off();
+  const fetchResult = await fetch(CAT_FACT_URL);
+  if (!fetchResult.ok) {
+    throw Error(`Failed fetching cat fact with code: ${fetchResult.status}`);
   }
+  const body = await fetchResult.json();
+  const fact = body.text;
+  console.log(`Got a new fact: ${fact}`);
+  return fact;
 };
 
 const App = () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,7 @@ const useUnmock = process.env.NODE_ENV === 'development';
 export const CAT_FACT_API_URL = 'https://cat-fact.herokuapp.com';
 export const CAT_FACT_PATH = '/facts/random?animal_type=cat&amount=1';
 
-export const unmockOn = (unmock: UnmockPackage) => {
+export const mockCatFactAPI = (unmock: UnmockPackage) => {
   unmock.on();
 
   unmock
@@ -20,7 +20,7 @@ export const unmockOn = (unmock: UnmockPackage) => {
 };
 
 if (useUnmock) {
-  unmockOn(unmock);
+  mockCatFactAPI(unmock);
 }
 
 const fetchFact = async () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,17 +1,31 @@
 import React, {useState, useEffect} from 'react';
 import {Button, StyleSheet, View, Text} from 'react-native';
 import {Colors} from 'react-native/Libraries/NewAppScreen';
-import unmock from 'unmock-react-native';
+import unmock, {u} from 'unmock';
 
 const useUnmock = true;
 
 const CAT_FACT_URL =
   'https://cat-fact.herokuapp.com/facts/random?animal_type=cat&amount=1';
 
+const unmockOn = () => {
+  unmock.on();
+  unmock
+    .nock('https://cat-fact.herokuapp.com', 'catFactApi')
+    .get('/facts/random?animal_type=cat&amount=1')
+    .reply(200, {text: u.string('lorem.sentence')})
+    .reply(500, 'Internal server error');
+  return unmock;
+};
+
 const fetchFact = async () => {
   console.log(`Fetching new cat fact`);
   if (useUnmock) {
     unmock.on();
+    unmock
+      .nock('https://cat-fact.herokuapp.com')
+      .get('/facts/random?animal_type=cat&amount=1')
+      .reply(200, {text: 'Fake fact from unmock'});
     console.log(`Unmock on`);
   }
   try {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,16 +4,12 @@ import {Colors} from 'react-native/Libraries/NewAppScreen';
 import unmock, {u} from 'unmock';
 import {buildFetch} from 'unmock-fetch';
 
-if (typeof Buffer === 'undefined') global.Buffer = require('buffer').Buffer;
-
-const useUnmock = true;
-
 const faker = unmock.newFaker();
 
 faker
   .nock('https://cat-fact.herokuapp.com')
   .get('/facts/random?animal_type=cat&amount=1')
-  .reply(200, {text: 'Fake fact from unmock'})
+  .reply(200, {text: u.string('lorem.sentence')})
   .reply(500, 'Internal server error');
 
 const fetch = buildFetch(faker.createResponse.bind(faker));
@@ -21,26 +17,7 @@ const fetch = buildFetch(faker.createResponse.bind(faker));
 const CAT_FACT_URL =
   'https://cat-fact.herokuapp.com/facts/random?animal_type=cat&amount=1';
 
-const unmockOn = () => {
-  unmock.on();
-  unmock
-    .nock('https://cat-fact.herokuapp.com', 'catFactApi')
-    .get('/facts/random?animal_type=cat&amount=1')
-    .reply(200, {text: u.string('lorem.sentence')})
-    .reply(500, 'Internal server error');
-  return unmock;
-};
-
 const fetchFact = async () => {
-  // console.log(`Fetching new cat fact`);
-  /* if (useUnmock) {
-    unmock.on();
-    unmock
-      .nock('https://cat-fact.herokuapp.com')
-      .get('/facts/random?animal_type=cat&amount=1')
-      .reply(200, {text: 'Fake fact from unmock'});
-    // console.log(`Unmock on`);
-  } */
   try {
     const fetchResult = await fetch(CAT_FACT_URL);
     if (!fetchResult.ok) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -835,10 +835,10 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
-"@meeshkanml/json-schema-faker@^0.0.0":
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/@meeshkanml/json-schema-faker/-/json-schema-faker-0.0.0.tgz#98b71f779470c84779b35ab2bc50384799e79dfb"
-  integrity sha512-Jr1tV632neWm88/Axi8W3onhhWdhD40N1cbL2LZq6UnnhKOtkT6to78/pWscI244nYMsb+ka9DrwWKoqWes3BA==
+"@meeshkanml/json-schema-faker@^0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@meeshkanml/json-schema-faker/-/json-schema-faker-0.0.1.tgz#67c57a1cfd682667a0e2e52fbb28b8c2ceec1356"
+  integrity sha512-KFVv4udZITeR97+9SnkWXZLR/7TKV3bS5A6hAc5UUH2WFv+MQDKbib77Le9Btdnkdk7IwbOa9KrBJXIZb/aKSw==
   dependencies:
     "@meeshkanml/json-schema-ref-parser" "0.0.0"
     jsonpath-plus "^1.0.0"
@@ -7051,8 +7051,8 @@ universalify@^0.1.0:
   version "0.3.8"
   dependencies:
     buffer "^5.4.3"
-    unmock-core "file:../../../Library/Caches/Yarn/v4/npm-unmock-browser-0.3.8-4b51eb75-3a39-43a5-a0c5-b95add3e1546-1576567727104/node_modules/unmock-core"
-    unmock-fetch "file:../../../Library/Caches/Yarn/v4/npm-unmock-browser-0.3.8-4b51eb75-3a39-43a5-a0c5-b95add3e1546-1576567727104/node_modules/unmock-fetch"
+    unmock-core "file:../../../Library/Caches/Yarn/v4/npm-unmock-browser-0.3.8-45bae694-9c87-4840-8f5e-4c9a275a2a86-1576570282984/node_modules/unmock-core"
+    unmock-fetch "file:../../../Library/Caches/Yarn/v4/npm-unmock-browser-0.3.8-45bae694-9c87-4840-8f5e-4c9a275a2a86-1576570282984/node_modules/unmock-fetch"
 
 "unmock-cli@file:../unmock-js/packages/unmock-cli":
   version "0.3.10"
@@ -7062,13 +7062,13 @@ universalify@^0.1.0:
     commander "^2.20.0"
     glob "^7.1.3"
     readline-sync "^1.4.10"
-    unmock-core "file:../../../Library/Caches/Yarn/v4/npm-unmock-cli-0.3.10-a389e0bc-0c12-4977-9c11-0a62add12029-1576567727105/node_modules/unmock-core"
-    unmock-node "file:../../../Library/Caches/Yarn/v4/npm-unmock-cli-0.3.10-a389e0bc-0c12-4977-9c11-0a62add12029-1576567727105/node_modules/unmock-node"
+    unmock-core "file:../../../Library/Caches/Yarn/v4/npm-unmock-cli-0.3.10-882d2023-4aa0-4c31-b17f-e5f43439a56b-1576570282922/node_modules/unmock-core"
+    unmock-node "file:../../../Library/Caches/Yarn/v4/npm-unmock-cli-0.3.10-882d2023-4aa0-4c31-b17f-e5f43439a56b-1576570282922/node_modules/unmock-node"
 
 "unmock-core@file:../unmock-js/packages/unmock-core":
   version "0.3.10"
   dependencies:
-    "@meeshkanml/json-schema-faker" "^0.0.0"
+    "@meeshkanml/json-schema-faker" "^0.0.1"
     "@meeshkanml/jsonschema" "^0.0.1"
     "@types/sinon" "^7.0.13"
     "@types/whatwg-url" "^6.4.0"
@@ -7089,7 +7089,7 @@ universalify@^0.1.0:
     lodash "^4.17.14"
     minimatch "^3.0.4"
     monocle-ts "^2.0.0"
-    openapi-refinements "file:../../../Library/Caches/Yarn/v4/npm-unmock-core-0.3.10-03d578d5-8d3a-4522-89cd-d64fcbcae442-1576567727107/node_modules/openapi-refinements"
+    openapi-refinements "file:../../../Library/Caches/Yarn/v4/npm-unmock-core-0.3.10-172a600f-38e3-4ee7-97be-2ef950bf6d58-1576570282924/node_modules/openapi-refinements"
     query-string "^6.8.3"
     seedrandom "^3.0.3"
     sinon "^7.4.1"
@@ -7104,7 +7104,7 @@ universalify@^0.1.0:
     "@types/url-parse" "^1.4.3"
     cross-fetch "^3.0.4"
     debug "^4.1.1"
-    unmock-core "file:../../../Library/Caches/Yarn/v4/npm-unmock-fetch-0.3.10-d2fbe2a6-9ee7-48f8-b967-99980d991e10-1576567727189/node_modules/unmock-core"
+    unmock-core "file:../../../Library/Caches/Yarn/v4/npm-unmock-fetch-0.3.10-8177c7f0-242f-4c36-b69d-9d63ad35f9d9-1576570283003/node_modules/unmock-core"
     url-parse "^1.4.7"
 
 "unmock-node@file:../unmock-js/packages/unmock-node":
@@ -7121,17 +7121,17 @@ universalify@^0.1.0:
     node-fetch "^2.6.0"
     readable-stream "^3.4.0"
     shimmer "^1.2.1"
-    unmock-core "file:../../../Library/Caches/Yarn/v4/npm-unmock-node-0.3.10-f79407ab-3242-455c-870c-6eeaf4038c25-1576567727092/node_modules/unmock-core"
+    unmock-core "file:../../../Library/Caches/Yarn/v4/npm-unmock-node-0.3.10-d0fc262a-78c5-4021-968c-83c076a9e1e5-1576570282909/node_modules/unmock-core"
     uuid "^3.3.2"
     winston "^3.2.1"
 
 "unmock@file:../unmock-js/packages/unmock":
   version "0.3.10"
   dependencies:
-    unmock-browser "file:../../../Library/Caches/Yarn/v4/npm-unmock-0.3.10-ed90b6de-13bb-414e-a841-cdff9ec31026-1576567727088/node_modules/unmock-browser"
-    unmock-cli "file:../../../Library/Caches/Yarn/v4/npm-unmock-0.3.10-ed90b6de-13bb-414e-a841-cdff9ec31026-1576567727088/node_modules/unmock-cli"
-    unmock-core "file:../../../Library/Caches/Yarn/v4/npm-unmock-0.3.10-ed90b6de-13bb-414e-a841-cdff9ec31026-1576567727088/node_modules/unmock-core"
-    unmock-node "file:../../../Library/Caches/Yarn/v4/npm-unmock-0.3.10-ed90b6de-13bb-414e-a841-cdff9ec31026-1576567727088/node_modules/unmock-node"
+    unmock-browser "file:../../../Library/Caches/Yarn/v4/npm-unmock-0.3.10-86643492-6742-464d-8be4-bc83668a4a9d-1576570282904/node_modules/unmock-browser"
+    unmock-cli "file:../../../Library/Caches/Yarn/v4/npm-unmock-0.3.10-86643492-6742-464d-8be4-bc83668a4a9d-1576570282904/node_modules/unmock-cli"
+    unmock-core "file:../../../Library/Caches/Yarn/v4/npm-unmock-0.3.10-86643492-6742-464d-8be4-bc83668a4a9d-1576570282904/node_modules/unmock-core"
+    unmock-node "file:../../../Library/Caches/Yarn/v4/npm-unmock-0.3.10-86643492-6742-464d-8be4-bc83668a4a9d-1576570282904/node_modules/unmock-node"
 
 unpipe@~1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -835,6 +835,13 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
+"@meeshkanml/jsonschema@^0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@meeshkanml/jsonschema/-/jsonschema-0.0.1.tgz#989ff388c54785708701001e1be43bcfe7bd5e8f"
+  integrity sha512-p/B7xS6hK0umAG2qEtdca6/yIwfBYEY+OFM/FwS6IpHdUpqOQ1AH5++KI45hCv5tBjxz8IebFzkIRFifXPXI0Q==
+  dependencies:
+    url-parse "^1.4.7"
+
 "@react-native-community/cli-platform-android@^3.0.0-alpha.1", "@react-native-community/cli-platform-android@^3.0.0-alpha.2":
   version "3.0.0-alpha.2"
   resolved "https://registry.yarnpkg.com/@react-native-community/cli-platform-android/-/cli-platform-android-3.0.0-alpha.2.tgz#63cb00060c58a87d04b46229ef7140e056551dfa"
@@ -985,6 +992,11 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/debug@^4.1.5":
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.5.tgz#b14efa8852b7768d898906613c23f688713e02cd"
+  integrity sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ==
+
 "@types/eslint-visitor-keys@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
@@ -1069,6 +1081,18 @@
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
+
+"@types/url-parse@^1.4.3":
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/@types/url-parse/-/url-parse-1.4.3.tgz#fba49d90f834951cb000a674efee3d6f20968329"
+  integrity sha512-4kHAkbV/OfW2kb5BLVUuUMoumB3CP8rHqlw48aHvFy5tf9ER0AfOonBlX29l/DD68G70DmyhRlSYfQPSYpC5Vw==
+
+"@types/whatwg-url@^6.4.0":
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/@types/whatwg-url/-/whatwg-url-6.4.0.tgz#1e59b8c64bc0dbdf66d037cf8449d1c3d5270237"
+  integrity sha512-tonhlcbQ2eho09am6RHnHOgvtDfDYINd5rgxD+2YSkKENooVCFsWizJz139MQW/PV8FfClyKrNe9ZbdHrSCxGg==
+  dependencies:
+    "@types/node" "*"
 
 "@types/yargs-parser@*":
   version "13.1.0"
@@ -2099,6 +2123,14 @@ create-react-class@^15.6.3:
     fbjs "^0.8.9"
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
+
+cross-fetch@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.0.4.tgz#7bef7020207e684a7638ef5f2f698e24d9eb283c"
+  integrity sha512-MSHgpjQqgbT/94D4CyADeNoYh52zMkCX4pcJvPP5WqPsLFMKjr2TCMg381ox5qI0ii2dPwaLx/00477knXqXVw==
+  dependencies:
+    node-fetch "2.6.0"
+    whatwg-fetch "3.0.0"
 
 cross-spawn@^5.0.1, cross-spawn@^5.1.0:
   version "5.1.0"
@@ -5031,6 +5063,11 @@ node-fetch-h2@^2.3.0:
   dependencies:
     http2-client "^1.2.5"
 
+node-fetch@2.6.0, node-fetch@^2.2.0, node-fetch@^2.5.0, node-fetch@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
+  integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
+
 node-fetch@^1.0.1:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
@@ -5038,11 +5075,6 @@ node-fetch@^1.0.1:
   dependencies:
     encoding "^0.1.11"
     is-stream "^1.0.1"
-
-node-fetch@^2.2.0, node-fetch@^2.5.0, node-fetch@^2.6.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
-  integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -5332,6 +5364,11 @@ openapi-refinements@^0.3.8:
   integrity sha512-xlIZ2NR/ThugZqVRJkgj+90HpIlfOxlMtRxguGnDBO/A3xnV7Vfb/1xJmvx6jngqUUY9PfS7qjUkexzY4OQPNA==
   dependencies:
     jsonschema "^1.2.4"
+
+"openapi-refinements@file:../unmock-js/packages/openapi-refinements":
+  version "0.3.9"
+  dependencies:
+    "@meeshkanml/jsonschema" "^0.0.1"
 
 optimist@^0.6.1:
   version "0.6.1"
@@ -5729,6 +5766,11 @@ querystring@^0.2.0:
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
   integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
 
+querystringify@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.1.1.tgz#60e5a5fd64a7f8bfa4d2ab2ed6fdf4c85bad154e"
+  integrity sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==
+
 randexp@^0.5.3:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/randexp/-/randexp-0.5.3.tgz#f31c2de3148b30bdeb84b7c3f59b0ebb9fec3738"
@@ -6031,6 +6073,11 @@ require-main-filename@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
   integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
+
+requires-port@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
+  integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
 
 resolve-cwd@^2.0.0:
   version "2.0.0"
@@ -7071,6 +7118,54 @@ unmock-core@^0.3.8:
     uuid "^3.3.2"
     winston "^3.2.1"
 
+"unmock-core@file:../unmock-js/packages/unmock-core":
+  version "0.3.9"
+  dependencies:
+    "@meeshkanml/jsonschema" "^0.0.1"
+    "@types/sinon" "^7.0.13"
+    "@types/whatwg-url" "^6.4.0"
+    ajv "^6.10.0"
+    axios "^0.18.0"
+    chalk "^2.4.2"
+    debug "^4.1.1"
+    expect "^24.9.0"
+    faker "^4.1.0"
+    fp-ts "^2.0.5"
+    ini "^1.3.5"
+    io-ts "^2.0.1"
+    json-pointer "^0.6.0"
+    json-schema-deref-sync "^0.10.1"
+    json-schema-faker "^0.5.0-rc17"
+    json-schema-poet "0.0.9"
+    json-schema-strictly-typed "0.0.14"
+    loas3 "^0.1.4"
+    lodash "^4.17.14"
+    minimatch "^3.0.4"
+    monocle-ts "^2.0.0"
+    openapi-refinements "file:../../../Library/Caches/Yarn/v4/npm-unmock-core-0.3.9-39019704-b301-46a2-9412-7bc9eda60f6d-1571389979922/node_modules/openapi-refinements"
+    query-string "^6.8.3"
+    seedrandom "^3.0.3"
+    sinon "^7.4.1"
+    swagger2openapi "^5.3.0"
+    whatwg-url "^7.0.0"
+    winston "^3.2.1"
+
+"unmock-fetch@file:../unmock-js/packages/unmock-fetch":
+  version "0.3.9"
+  dependencies:
+    "@types/debug" "^4.1.5"
+    "@types/url-parse" "^1.4.3"
+    cross-fetch "^3.0.4"
+    debug "^4.1.1"
+    unmock-core "file:../../../Library/Caches/Yarn/v4/npm-unmock-fetch-0.3.9-550e11d5-1b97-41c4-add0-0487fa67cc1e-1571389979918/node_modules/unmock-core"
+    url-parse "^1.4.7"
+
+"unmock-react-native@file:../unmock-js/packages/unmock-react-native":
+  version "0.3.8"
+  dependencies:
+    unmock-core "file:../../../Library/Caches/Yarn/v4/npm-unmock-react-native-0.3.8-86b47a78-8cf6-4991-8cc5-215822396d43-1571389979914/node_modules/unmock-core"
+    unmock-fetch "file:../../../Library/Caches/Yarn/v4/npm-unmock-react-native-0.3.8-86b47a78-8cf6-4991-8cc5-215822396d43-1571389979914/node_modules/unmock-fetch"
+
 unmock@^0.3.8:
   version "0.3.8"
   resolved "https://registry.yarnpkg.com/unmock/-/unmock-0.3.8.tgz#068b74ca5dbcb14d7efe04878521f2683d3e758c"
@@ -7103,6 +7198,14 @@ urix@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
+
+url-parse@^1.4.7:
+  version "1.4.7"
+  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.4.7.tgz#a8a83535e8c00a316e403a5db4ac1b9b853ae278"
+  integrity sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==
+  dependencies:
+    querystringify "^2.1.1"
+    requires-port "^1.0.0"
 
 use@^3.1.0:
   version "3.1.1"
@@ -7202,7 +7305,7 @@ whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.3:
   dependencies:
     iconv-lite "0.4.24"
 
-whatwg-fetch@>=0.10.0, whatwg-fetch@^3.0.0:
+whatwg-fetch@3.0.0, whatwg-fetch@>=0.10.0, whatwg-fetch@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"
   integrity sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1072,6 +1072,11 @@
     "@types/prop-types" "*"
     csstype "^2.2.0"
 
+"@types/readline-sync@^1.4.3":
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/@types/readline-sync/-/readline-sync-1.4.3.tgz#eac55a39d5a349912062c9e5216cd550c07fd9c8"
+  integrity sha512-YP9NVli96E+qQLAF2db+VjnAUEeZcFVg4YnMgr8kpDUFwQBnj31rPLOVHmazbKQhaIkJ9cMHsZhpKdzUeL0KTg==
+
 "@types/sinon@^7.0.13":
   version "7.5.0"
   resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-7.5.0.tgz#f5a10c27175465a0b001b68d8b9f761582967cc6"
@@ -1236,13 +1241,6 @@ ajv@^6.10.0, ajv@^6.10.2, ajv@^6.5.5:
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
-
-ansi-align@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/ansi-align/-/ansi-align-3.0.0.tgz#b536b371cf687caaef236c18d3e21fe3797467cb"
-  integrity sha512-ZpClVKqXN3RGBmKibdfWzqCY4lnjEuoNzU5T0oEFpfd/z5qJHVarukridD4juLO2FXMiwUQxr9WqQtaYa8XRYw==
-  dependencies:
-    string-width "^3.0.0"
 
 ansi-colors@^1.0.1:
   version "1.1.0"
@@ -1652,20 +1650,6 @@ big-integer@^1.6.7:
   resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.47.tgz#e1e9320e26c4cc81f64fbf4b3bb20e025bf18e2d"
   integrity sha512-9t9f7X3as2XGX8b52GqG6ox0GvIdM86LyIXASJnDCFhYNgt+A+MByQZ3W2PyMRZjEvG5f8TEbSPfEotVuMJnQg==
 
-boxen@3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/boxen/-/boxen-3.2.0.tgz#fbdff0de93636ab4450886b6ff45b92d098f45eb"
-  integrity sha512-cU4J/+NodM3IHdSL2yN8bqYqnmlBTidDR4RC7nJs61ZmtGz8VZzM3HLQX0zY5mrSmPtR3xWwsq2jOUQqFZN8+A==
-  dependencies:
-    ansi-align "^3.0.0"
-    camelcase "^5.3.1"
-    chalk "^2.4.2"
-    cli-boxes "^2.2.0"
-    string-width "^3.0.0"
-    term-size "^1.2.0"
-    type-fest "^0.3.0"
-    widest-line "^2.0.0"
-
 bplist-creator@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/bplist-creator/-/bplist-creator-0.0.7.tgz#37df1536092824b87c42f957b01344117372ae45"
@@ -1847,11 +1831,6 @@ class-utils@^0.3.5:
     define-property "^0.2.5"
     isobject "^3.0.0"
     static-extend "^0.1.1"
-
-cli-boxes@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-2.2.0.tgz#538ecae8f9c6ca508e3c3c95b453fe93cb4c168d"
-  integrity sha512-gpaBrMAizVEANOpfZp/EEUixTXDyGt7DFzdK5hU+UbWt/J0lB0w20ncZj59Z9a93xHb9u12zF5BS6i9RKbtg4w==
 
 cli-cursor@^2.1.0:
   version "2.1.0"
@@ -4308,11 +4287,6 @@ jsonpointer@^4.0.1:
   resolved "https://registry.yarnpkg.com/jsonpointer/-/jsonpointer-4.0.1.tgz#4fd92cb34e0e9db3c89c8622ecf51f9b978c6cb9"
   integrity sha1-T9kss04OnbPInIYi7PUfm5eMbLk=
 
-jsonschema@^1.2.4:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/jsonschema/-/jsonschema-1.2.4.tgz#a46bac5d3506a254465bc548876e267c6d0d6464"
-  integrity sha512-lz1nOH69GbsVHeVgEdvyavc/33oymY1AZwtePMiMj4HZPMbP5OIKK3zT9INMWjwua/V4Z4yq7wSlBbSG+g4AEw==
-
 jsprim@^1.2.2:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2"
@@ -5358,15 +5332,8 @@ open@^6.2.0:
   dependencies:
     is-wsl "^1.1.0"
 
-openapi-refinements@^0.3.8:
-  version "0.3.8"
-  resolved "https://registry.yarnpkg.com/openapi-refinements/-/openapi-refinements-0.3.8.tgz#fb13e6fc0df60a8f9d94d9b5808de1ea9e5d57c9"
-  integrity sha512-xlIZ2NR/ThugZqVRJkgj+90HpIlfOxlMtRxguGnDBO/A3xnV7Vfb/1xJmvx6jngqUUY9PfS7qjUkexzY4OQPNA==
-  dependencies:
-    jsonschema "^1.2.4"
-
 "openapi-refinements@file:../unmock-js/packages/openapi-refinements":
-  version "0.3.9"
+  version "0.3.10"
   dependencies:
     "@meeshkanml/jsonschema" "^0.0.1"
 
@@ -5761,11 +5728,6 @@ query-string@^6.8.3:
     split-on-first "^1.0.0"
     strict-uri-encode "^2.0.0"
 
-querystring@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
-  integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
-
 querystringify@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.1.1.tgz#60e5a5fd64a7f8bfa4d2ab2ed6fdf4c85bad154e"
@@ -5928,6 +5890,11 @@ readable-stream@^3.1.1, readable-stream@^3.4.0:
     inherits "^2.0.3"
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
+
+readline-sync@^1.4.10:
+  version "1.4.10"
+  resolved "https://registry.yarnpkg.com/readline-sync/-/readline-sync-1.4.10.tgz#41df7fbb4b6312d673011594145705bf56d8873b"
+  integrity sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw==
 
 realpath-native@^1.1.0:
   version "1.1.0"
@@ -6810,13 +6777,6 @@ temp@0.8.3:
     os-tmpdir "^1.0.0"
     rimraf "~2.2.6"
 
-term-size@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/term-size/-/term-size-1.2.0.tgz#458b83887f288fc56d6fffbfad262e26638efa69"
-  integrity sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=
-  dependencies:
-    execa "^0.7.0"
-
 test-exclude@^5.2.3:
   version "5.2.3"
   resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-5.2.3.tgz#c3d3e1e311eb7ee405e092dac10aefd09091eac0"
@@ -6976,11 +6936,6 @@ type-detect@4.0.8:
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
 
-type-fest@^0.3.0:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.3.1.tgz#63d00d204e059474fe5e1b7c011112bbd1dc29e1"
-  integrity sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==
-
 type-fest@^0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.7.1.tgz#8dda65feaf03ed78f0a3f9678f1869147f7c5c48"
@@ -7065,61 +7020,25 @@ universalify@^0.1.0:
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
   integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
 
-unmock-cli@^0.3.8:
+"unmock-browser@file:../unmock-js/packages/unmock-browser":
   version "0.3.8"
-  resolved "https://registry.yarnpkg.com/unmock-cli/-/unmock-cli-0.3.8.tgz#b901cccb2036098524af1d42492c3dd97f921b35"
-  integrity sha512-lHhSQhddoKV9ut0owe3dO6uyVNEmAUhN2HOrVYhAHjbzRHAgHOcAOpVnmrnTx7oP3eZ+j3kkoHXAwIFsN8YCDQ==
   dependencies:
+    unmock-core "file:../../../Library/Caches/Yarn/v4/npm-unmock-browser-0.3.8-cae81706-7f3c-4320-ae00-0cc1d074af88-1576141184670/node_modules/unmock-core"
+    unmock-fetch "file:../../../Library/Caches/Yarn/v4/npm-unmock-browser-0.3.8-cae81706-7f3c-4320-ae00-0cc1d074af88-1576141184670/node_modules/unmock-fetch"
+
+"unmock-cli@file:../unmock-js/packages/unmock-cli":
+  version "0.3.10"
+  dependencies:
+    "@types/readline-sync" "^1.4.3"
+    chalk "^2.4.2"
     commander "^2.20.0"
     glob "^7.1.3"
-    unmock-core "^0.3.8"
-
-unmock-core@^0.3.8:
-  version "0.3.8"
-  resolved "https://registry.yarnpkg.com/unmock-core/-/unmock-core-0.3.8.tgz#2fc6ff66195c189180a992055caeea34a5e211e0"
-  integrity sha512-r6JgtRSNbD9lMzCojKEVOPe8smnPiwTu+GZg3rjvTBHrNWNPQfIyzr89Fh1HsyiAyR4dc6AqSj/rZqwQJhRV2Q==
-  dependencies:
-    "@types/node" "^12.7.8"
-    "@types/node-fetch" "^2.5.2"
-    "@types/sinon" "^7.0.13"
-    ajv "^6.10.0"
-    app-root-path "^2.2.1"
-    axios "^0.18.0"
-    boxen "3.2.0"
-    chalk "^2.4.2"
-    debug "^4.1.1"
-    expect "^24.9.0"
-    faker "^4.1.0"
-    fp-ts "^2.0.5"
-    ini "^1.3.5"
-    io-ts "^2.0.1"
-    js-yaml "^3.13.1"
-    json-pointer "^0.6.0"
-    json-schema-deref-sync "^0.10.1"
-    json-schema-faker "^0.5.0-rc17"
-    json-schema-poet "0.0.9"
-    json-schema-strictly-typed "0.0.14"
-    jsonschema "^1.2.4"
-    loas3 "^0.1.4"
-    lodash "^4.17.14"
-    minimatch "^3.0.4"
-    mitm "^1.7.0"
-    mkdirp "^0.5.1"
-    monocle-ts "^2.0.0"
-    node-fetch "^2.6.0"
-    openapi-refinements "^0.3.8"
-    query-string "^6.8.3"
-    querystring "^0.2.0"
-    readable-stream "^3.4.0"
-    seedrandom "^3.0.3"
-    shimmer "^1.2.1"
-    sinon "^7.4.1"
-    swagger2openapi "^5.3.0"
-    uuid "^3.3.2"
-    winston "^3.2.1"
+    readline-sync "^1.4.10"
+    unmock-core "file:../../../Library/Caches/Yarn/v4/npm-unmock-cli-0.3.10-e662b680-b562-4d06-9f0b-38c940deb9a7-1576141184671/node_modules/unmock-core"
+    unmock-node "file:../../../Library/Caches/Yarn/v4/npm-unmock-cli-0.3.10-e662b680-b562-4d06-9f0b-38c940deb9a7-1576141184671/node_modules/unmock-node"
 
 "unmock-core@file:../unmock-js/packages/unmock-core":
-  version "0.3.9"
+  version "0.3.10"
   dependencies:
     "@meeshkanml/jsonschema" "^0.0.1"
     "@types/sinon" "^7.0.13"
@@ -7142,7 +7061,7 @@ unmock-core@^0.3.8:
     lodash "^4.17.14"
     minimatch "^3.0.4"
     monocle-ts "^2.0.0"
-    openapi-refinements "file:../../../Library/Caches/Yarn/v4/npm-unmock-core-0.3.9-39019704-b301-46a2-9412-7bc9eda60f6d-1571389979922/node_modules/openapi-refinements"
+    openapi-refinements "file:../../../Library/Caches/Yarn/v4/npm-unmock-core-0.3.10-2554734c-3c65-4e40-9bbe-2e7ff329632c-1576141184695/node_modules/openapi-refinements"
     query-string "^6.8.3"
     seedrandom "^3.0.3"
     sinon "^7.4.1"
@@ -7151,28 +7070,40 @@ unmock-core@^0.3.8:
     winston "^3.2.1"
 
 "unmock-fetch@file:../unmock-js/packages/unmock-fetch":
-  version "0.3.9"
+  version "0.3.10"
   dependencies:
     "@types/debug" "^4.1.5"
     "@types/url-parse" "^1.4.3"
     cross-fetch "^3.0.4"
     debug "^4.1.1"
-    unmock-core "file:../../../Library/Caches/Yarn/v4/npm-unmock-fetch-0.3.9-550e11d5-1b97-41c4-add0-0487fa67cc1e-1571389979918/node_modules/unmock-core"
+    unmock-core "file:../../../Library/Caches/Yarn/v4/npm-unmock-fetch-0.3.10-8e310719-1b6d-4629-9d0e-a9062237e1c9-1576141184736/node_modules/unmock-core"
     url-parse "^1.4.7"
 
-"unmock-react-native@file:../unmock-js/packages/unmock-react-native":
-  version "0.3.8"
+"unmock-node@file:../unmock-js/packages/unmock-node":
+  version "0.3.10"
   dependencies:
-    unmock-core "file:../../../Library/Caches/Yarn/v4/npm-unmock-react-native-0.3.8-86b47a78-8cf6-4991-8cc5-215822396d43-1571389979914/node_modules/unmock-core"
-    unmock-fetch "file:../../../Library/Caches/Yarn/v4/npm-unmock-react-native-0.3.8-86b47a78-8cf6-4991-8cc5-215822396d43-1571389979914/node_modules/unmock-fetch"
+    "@types/node" "^12.7.8"
+    "@types/node-fetch" "^2.5.2"
+    app-root-path "^2.2.1"
+    debug "^4.1.1"
+    js-yaml "^3.13.1"
+    lodash "^4.17.14"
+    mitm "^1.7.0"
+    mkdirp "^0.5.1"
+    node-fetch "^2.6.0"
+    readable-stream "^3.4.0"
+    shimmer "^1.2.1"
+    unmock-core "file:../../../Library/Caches/Yarn/v4/npm-unmock-node-0.3.10-6e878605-1bcb-4a23-bbe4-f15ded18e342-1576141184680/node_modules/unmock-core"
+    uuid "^3.3.2"
+    winston "^3.2.1"
 
-unmock@^0.3.8:
-  version "0.3.8"
-  resolved "https://registry.yarnpkg.com/unmock/-/unmock-0.3.8.tgz#068b74ca5dbcb14d7efe04878521f2683d3e758c"
-  integrity sha512-3797GFmN2YgZrj82CRb3U9J7tjacycwdKN4vyvpyAAh3XmFGDN7Q2NonnxGwq2NtHVr5iNZI5HMbjp6xwJTAuw==
+"unmock@file:../unmock-js/packages/unmock":
+  version "0.3.10"
   dependencies:
-    unmock-cli "^0.3.8"
-    unmock-core "^0.3.8"
+    unmock-browser "file:../../../Library/Caches/Yarn/v4/npm-unmock-0.3.10-1e680756-ae19-4af9-9809-f40762499118-1576141184665/node_modules/unmock-browser"
+    unmock-cli "file:../../../Library/Caches/Yarn/v4/npm-unmock-0.3.10-1e680756-ae19-4af9-9809-f40762499118-1576141184665/node_modules/unmock-cli"
+    unmock-core "file:../../../Library/Caches/Yarn/v4/npm-unmock-0.3.10-1e680756-ae19-4af9-9809-f40762499118-1576141184665/node_modules/unmock-core"
+    unmock-node "file:../../../Library/Caches/Yarn/v4/npm-unmock-0.3.10-1e680756-ae19-4af9-9809-f40762499118-1576141184665/node_modules/unmock-node"
 
 unpipe@~1.0.0:
   version "1.0.0"
@@ -7351,13 +7282,6 @@ wide-align@^1.1.0:
   integrity sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==
   dependencies:
     string-width "^1.0.2 || 2"
-
-widest-line@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/widest-line/-/widest-line-2.0.1.tgz#7438764730ec7ef4381ce4df82fb98a53142a3fc"
-  integrity sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==
-  dependencies:
-    string-width "^2.1.1"
 
 winston-transport@^4.3.0:
   version "4.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -607,7 +607,7 @@
     pirates "^4.0.0"
     source-map-support "^0.5.9"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.3":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.6.3":
   version "7.6.3"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.6.3.tgz#935122c74c73d2240cafd32ddb5fc2a6cd35cf1f"
   integrity sha512-kq6anf9JGjW8Nt5rYfEuGRaEAaH1mkv3Bbu6rYvLOpPh/RusSJXuKPEAoZ7L7gybZkchE8+NV5g9vKF4AGAtsA==
@@ -1040,16 +1040,16 @@
   integrity sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==
 
 "@types/node-fetch@^2.5.2":
-  version "2.5.2"
-  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.2.tgz#76906dea5b3d6901e50e63e15249c9bcd6e9676e"
-  integrity sha512-djYYKmdNRSBtL1x4CiE9UJb9yZhwtI1VC+UxZD0psNznrUj80ywsxKlEGAE+QL1qvLjPbfb24VosjkYM6W4RSQ==
+  version "2.5.4"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.4.tgz#5245b6d8841fc3a6208b82291119bc11c4e0ce44"
+  integrity sha512-Oz6id++2qAOFuOlE1j0ouk1dzl3mmI1+qINPNBhi9nt/gVOz0G+13Ao6qjhdF0Ys+eOkhu6JnFmt38bR3H0POQ==
   dependencies:
     "@types/node" "*"
 
 "@types/node@*", "@types/node@^12.7.8":
-  version "12.7.12"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.7.12.tgz#7c6c571cc2f3f3ac4a59a5f2bd48f5bdbc8653cc"
-  integrity sha512-KPYGmfD0/b1eXurQ59fXD1GBzhSQfz6/lKBxkaHX9dKTzjXbK68Zt7yGUxUsCS1jeTy/8aL+d9JEr+S54mpkWQ==
+  version "12.12.17"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.17.tgz#191b71e7f4c325ee0fb23bc4a996477d92b8c39b"
+  integrity sha512-Is+l3mcHvs47sKy+afn2O1rV4ldZFU7W8101cNlOd+MRbjM4Onida8jSZnJdTe/0Pcf25g9BNIUsuugmE6puHA==
 
 "@types/prop-types@*":
   version "15.7.3"
@@ -1078,9 +1078,9 @@
   integrity sha512-YP9NVli96E+qQLAF2db+VjnAUEeZcFVg4YnMgr8kpDUFwQBnj31rPLOVHmazbKQhaIkJ9cMHsZhpKdzUeL0KTg==
 
 "@types/sinon@^7.0.13":
-  version "7.5.0"
-  resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-7.5.0.tgz#f5a10c27175465a0b001b68d8b9f761582967cc6"
-  integrity sha512-NyzhuSBy97B/zE58cDw4NyGvByQbAHNP9069KVSgnXt/sc0T6MFRh0InKAeBVHJWdSXG1S3+PxgVIgKo9mTHbw==
+  version "7.5.1"
+  resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-7.5.1.tgz#d27b81af0d1cfe1f9b24eebe7a24f74ae40f5b7c"
+  integrity sha512-EZQUP3hSZQyTQRfiLqelC9NMWd1kqLcmQE0dMiklxBkgi84T+cHOhnKpgk4NnOWpGX863yE6+IaGnOXUNFqDnQ==
 
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
@@ -1587,7 +1587,7 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
-base64-js@^1.1.2, base64-js@^1.2.3:
+base64-js@^1.0.2, base64-js@^1.1.2, base64-js@^1.2.3:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.1.tgz#58ece8cb75dd07e71ed08c736abc5fac4dbf8df1"
   integrity sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==
@@ -1716,6 +1716,14 @@ buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
+
+buffer@^5.4.3:
+  version "5.4.3"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.4.3.tgz#3fbc9c69eb713d323e3fc1a895eee0710c072115"
+  integrity sha512-zvj65TkFeIt3i6aj5bIvJDzjjQQGs4o/sNoezg1F1kYap9Nu2jcUdpwzRSJTHMMzG0H7bZkn4rNQpImhuxWX2A==
+  dependencies:
+    base64-js "^1.0.2"
+    ieee754 "^1.1.4"
 
 bytes@3.0.0:
   version "3.0.0"
@@ -1982,10 +1990,15 @@ commander@2.20.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
   integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
 
-commander@^2.19.0, commander@^2.20.0:
+commander@^2.19.0:
   version "2.20.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.1.tgz#3863ce3ca92d0831dcf2a102f5fb4b5926afd0f9"
   integrity sha512-cCuLsMhJeWQ/ZpsFTbE765kvVfoeSddc4nU3up4fV+fDBcfUXnbITJ+JzhkdjzOqhURjZgujxaioam4RM9yGUg==
+
+commander@^2.20.0:
+  version "2.20.3"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
+  integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
 commander@~2.13.0:
   version "2.13.0"
@@ -2069,15 +2082,20 @@ core-js@^1.0.0:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
   integrity sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=
 
-core-js@^2.2.2, core-js@^2.4.1, core-js@^2.5.7:
+core-js@^2.2.2, core-js@^2.4.1:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.9.tgz#6b4b214620c834152e179323727fc19741b084f2"
   integrity sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==
 
+core-js@^2.5.7:
+  version "2.6.11"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.11.tgz#38831469f9922bded8ee21c9dc46985e0399308c"
+  integrity sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==
+
 core-js@^3.2.1:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.2.1.tgz#cd41f38534da6cc59f7db050fe67307de9868b09"
-  integrity sha512-Qa5XSVefSVPRxy2XfUC13WbvqkxhkwB3ve+pgCQveNgYzbM/UxZeu1dcOX/xr4UmfUd+muuvsaxilQzCyUurMw==
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.5.0.tgz#66df8e49be4bd775e6f952a9d083b756ad41c1ed"
+  integrity sha512-Ifh3kj78gzQ7NAoJXeTu+XwzDld0QRIwjBLRqAMhuLhP3d2Av5wmgE9ycfnvK6NAEjTkQ1sDPeoEZAWO3Hx1Uw==
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -3015,9 +3033,9 @@ fp-ts@^1.0.0:
   integrity sha512-wDNqTimnzs8QqpldiId9OavWK2NptormjXnRJTQecNjzwfyp6P/8s/zG8e4h3ja3oqkKaY72UlTjQYt/1yXf9A==
 
 fp-ts@^2.0.0, fp-ts@^2.0.5:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/fp-ts/-/fp-ts-2.1.0.tgz#dac1b13ade6d52deb823bee53e99e3a804cc6e05"
-  integrity sha512-2xTHhLuP0uLjpaHAARpGQ1TpIPqEUMu8fGN5jv8py0T+HgB6a4bV57p5EQoOyeHws4SuYxiUi2/m0isHs6F/cA==
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/fp-ts/-/fp-ts-2.3.1.tgz#8068bfcca118227932941101e062134d7ecd9119"
+  integrity sha512-KevPBnYt0aaJiuUzmU9YIxjrhC9AgJ8CLtLlXmwArovlNTeYM5NtEoKd86B0wHd7FIbzeE8sNXzCoYIOr7e6Iw==
 
 fragment-cache@^0.2.1:
   version "0.2.1"
@@ -3291,6 +3309,11 @@ iconv-lite@0.4.24, iconv-lite@^0.4.17, iconv-lite@^0.4.24, iconv-lite@^0.4.4, ic
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
+
+ieee754@^1.1.4:
+  version "1.1.13"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"
+  integrity sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==
 
 ignore-walk@^3.0.1:
   version "3.0.3"
@@ -4178,9 +4201,9 @@ json-schema-deref-sync@^0.10.1:
     valid-url "~1.0.9"
 
 json-schema-faker@^0.5.0-rc17:
-  version "0.5.0-rc19"
-  resolved "https://registry.yarnpkg.com/json-schema-faker/-/json-schema-faker-0.5.0-rc19.tgz#185d80905c40fda93bf44c61f09ea9d887a6bf69"
-  integrity sha512-yJLDodgoc/BOONGFmyuKoj3bSRXZ55FWIp1WjN0yC76kfoIz+lI5ttjUtU8NxgNULGFppJzpUM0ydyAWH3qp7A==
+  version "0.5.0-rc23"
+  resolved "https://registry.yarnpkg.com/json-schema-faker/-/json-schema-faker-0.5.0-rc23.tgz#f6cfab390e429b1f57ac83199480439db60962fa"
+  integrity sha512-lRzFEnp55TihRzMvUBrtvTlM/aHGhCwfes0/T9bN9OiB2n36/SUFxtMn7anYoES+f95eU3viJ/foXKosCwsiJw==
   dependencies:
     json-schema-ref-parser "^6.1.0"
     jsonpath-plus "^1.0.0"
@@ -5538,9 +5561,9 @@ path-parse@^1.0.6:
   integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
 
 path-to-regexp@^1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
-  integrity sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.8.0.tgz#887b3ba9d84393e87a0a0b9f4cb756198b53548a"
+  integrity sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==
   dependencies:
     isarray "0.0.1"
 
@@ -5633,9 +5656,9 @@ prettier@1.16.4:
   integrity sha512-ZzWuos7TI5CKUeQAtFd6Zhm2s6EpAD/ZLApIhsF9pRvRtM1RFo61dM/4MSRUA0SuLugA/zgrZD8m0BaY46Og7g==
 
 prettier@^1.18.2:
-  version "1.18.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
-  integrity sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==
+  version "1.19.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
+  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
 
 pretty-format@^24.0.0, pretty-format@^24.7.0, pretty-format@^24.9.0:
   version "24.9.0"
@@ -5704,6 +5727,11 @@ pump@^3.0.0:
     end-of-stream "^1.1.0"
     once "^1.3.1"
 
+punycode@1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
+  integrity sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=
+
 punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
@@ -5720,13 +5748,18 @@ qs@~6.5.2:
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
 
 query-string@^6.8.3:
-  version "6.8.3"
-  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.8.3.tgz#fd9fb7ffb068b79062b43383685611ee47777d4b"
-  integrity sha512-llcxWccnyaWlODe7A9hRjkvdCKamEKTh+wH8ITdTc3OhchaqUZteiSCX/2ablWHVrkVIe04dntnaZJ7BdyW0lQ==
+  version "6.9.0"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.9.0.tgz#1c3b727c370cf00f177c99f328fda2108f8fa3dd"
+  integrity sha512-KG4bhCFYapExLsUHrFt+kQVEegF2agm4cpF/VNc6pZVthIfCc/GK8t8VyNIE3nyXG9DK3Tf2EGkxjR6/uRdYsA==
   dependencies:
     decode-uri-component "^0.2.0"
     split-on-first "^1.0.0"
     strict-uri-encode "^2.0.0"
+
+querystring@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
+  integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
 
 querystringify@^2.1.1:
   version "2.1.1"
@@ -7023,8 +7056,8 @@ universalify@^0.1.0:
 "unmock-browser@file:../unmock-js/packages/unmock-browser":
   version "0.3.8"
   dependencies:
-    unmock-core "file:../../../Library/Caches/Yarn/v4/npm-unmock-browser-0.3.8-cae81706-7f3c-4320-ae00-0cc1d074af88-1576141184670/node_modules/unmock-core"
-    unmock-fetch "file:../../../Library/Caches/Yarn/v4/npm-unmock-browser-0.3.8-cae81706-7f3c-4320-ae00-0cc1d074af88-1576141184670/node_modules/unmock-fetch"
+    unmock-core "file:../../../Library/Caches/Yarn/v4/npm-unmock-browser-0.3.8-e1348f2d-7d68-4838-b13a-a86e74598369-1576483377129/node_modules/unmock-core"
+    unmock-fetch "file:../../../Library/Caches/Yarn/v4/npm-unmock-browser-0.3.8-e1348f2d-7d68-4838-b13a-a86e74598369-1576483377129/node_modules/unmock-fetch"
 
 "unmock-cli@file:../unmock-js/packages/unmock-cli":
   version "0.3.10"
@@ -7034,8 +7067,8 @@ universalify@^0.1.0:
     commander "^2.20.0"
     glob "^7.1.3"
     readline-sync "^1.4.10"
-    unmock-core "file:../../../Library/Caches/Yarn/v4/npm-unmock-cli-0.3.10-e662b680-b562-4d06-9f0b-38c940deb9a7-1576141184671/node_modules/unmock-core"
-    unmock-node "file:../../../Library/Caches/Yarn/v4/npm-unmock-cli-0.3.10-e662b680-b562-4d06-9f0b-38c940deb9a7-1576141184671/node_modules/unmock-node"
+    unmock-core "file:../../../Library/Caches/Yarn/v4/npm-unmock-cli-0.3.10-7f6e61ab-021d-4191-aa51-fe3008197d6c-1576483377130/node_modules/unmock-core"
+    unmock-node "file:../../../Library/Caches/Yarn/v4/npm-unmock-cli-0.3.10-7f6e61ab-021d-4191-aa51-fe3008197d6c-1576483377130/node_modules/unmock-node"
 
 "unmock-core@file:../unmock-js/packages/unmock-core":
   version "0.3.10"
@@ -7061,7 +7094,7 @@ universalify@^0.1.0:
     lodash "^4.17.14"
     minimatch "^3.0.4"
     monocle-ts "^2.0.0"
-    openapi-refinements "file:../../../Library/Caches/Yarn/v4/npm-unmock-core-0.3.10-2554734c-3c65-4e40-9bbe-2e7ff329632c-1576141184695/node_modules/openapi-refinements"
+    openapi-refinements "file:../../../Library/Caches/Yarn/v4/npm-unmock-core-0.3.10-39690c4f-ebce-491e-9a27-172c80e16dbb-1576483377144/node_modules/openapi-refinements"
     query-string "^6.8.3"
     seedrandom "^3.0.3"
     sinon "^7.4.1"
@@ -7076,7 +7109,7 @@ universalify@^0.1.0:
     "@types/url-parse" "^1.4.3"
     cross-fetch "^3.0.4"
     debug "^4.1.1"
-    unmock-core "file:../../../Library/Caches/Yarn/v4/npm-unmock-fetch-0.3.10-8e310719-1b6d-4629-9d0e-a9062237e1c9-1576141184736/node_modules/unmock-core"
+    unmock-core "file:../../../Library/Caches/Yarn/v4/npm-unmock-fetch-0.3.10-8f40124c-5b35-484c-87d7-947ee24414e3-1576483377173/node_modules/unmock-core"
     url-parse "^1.4.7"
 
 "unmock-node@file:../unmock-js/packages/unmock-node":
@@ -7093,17 +7126,17 @@ universalify@^0.1.0:
     node-fetch "^2.6.0"
     readable-stream "^3.4.0"
     shimmer "^1.2.1"
-    unmock-core "file:../../../Library/Caches/Yarn/v4/npm-unmock-node-0.3.10-6e878605-1bcb-4a23-bbe4-f15ded18e342-1576141184680/node_modules/unmock-core"
+    unmock-core "file:../../../Library/Caches/Yarn/v4/npm-unmock-node-0.3.10-f92d11a8-f054-459b-89ae-c366c4781872-1576483377132/node_modules/unmock-core"
     uuid "^3.3.2"
     winston "^3.2.1"
 
 "unmock@file:../unmock-js/packages/unmock":
   version "0.3.10"
   dependencies:
-    unmock-browser "file:../../../Library/Caches/Yarn/v4/npm-unmock-0.3.10-1e680756-ae19-4af9-9809-f40762499118-1576141184665/node_modules/unmock-browser"
-    unmock-cli "file:../../../Library/Caches/Yarn/v4/npm-unmock-0.3.10-1e680756-ae19-4af9-9809-f40762499118-1576141184665/node_modules/unmock-cli"
-    unmock-core "file:../../../Library/Caches/Yarn/v4/npm-unmock-0.3.10-1e680756-ae19-4af9-9809-f40762499118-1576141184665/node_modules/unmock-core"
-    unmock-node "file:../../../Library/Caches/Yarn/v4/npm-unmock-0.3.10-1e680756-ae19-4af9-9809-f40762499118-1576141184665/node_modules/unmock-node"
+    unmock-browser "file:../../../Library/Caches/Yarn/v4/npm-unmock-0.3.10-88a8c1e3-d965-439d-87af-3f8b7b7fc456-1576483377124/node_modules/unmock-browser"
+    unmock-cli "file:../../../Library/Caches/Yarn/v4/npm-unmock-0.3.10-88a8c1e3-d965-439d-87af-3f8b7b7fc456-1576483377124/node_modules/unmock-cli"
+    unmock-core "file:../../../Library/Caches/Yarn/v4/npm-unmock-0.3.10-88a8c1e3-d965-439d-87af-3f8b7b7fc456-1576483377124/node_modules/unmock-core"
+    unmock-node "file:../../../Library/Caches/Yarn/v4/npm-unmock-0.3.10-88a8c1e3-d965-439d-87af-3f8b7b7fc456-1576483377124/node_modules/unmock-node"
 
 unpipe@~1.0.0:
   version "1.0.0"
@@ -7137,6 +7170,14 @@ url-parse@^1.4.7:
   dependencies:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
+
+url@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/url/-/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1"
+  integrity sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=
+  dependencies:
+    punycode "1.3.2"
+    querystring "0.2.0"
 
 use@^3.1.0:
   version "3.1.1"
@@ -7448,11 +7489,11 @@ yallist@^3.0.0, yallist@^3.0.3:
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
 
 yaml@^1.3.1:
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.7.1.tgz#86db1b39a6434a7928d3750cbe08303a50a24d6b"
-  integrity sha512-sR0mJ2C3LVBgMST+0zrrrsKSijbw64bfHmTt4nEXLZTZFyIAuUVARqA/LO5kaZav2OVQMaZ+5WRrZv7QjxG3uQ==
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.7.2.tgz#f26aabf738590ab61efaca502358e48dc9f348b2"
+  integrity sha512-qXROVp90sb83XtAoqE8bP9RwAkTTZbugRUTm5YeFCBfNRPEp2YzTeqWiz7m5OORHzEvrA/qcGS8hp/E+MMROYw==
   dependencies:
-    "@babel/runtime" "^7.5.5"
+    "@babel/runtime" "^7.6.3"
 
 yargs-parser@^11.1.1:
   version "11.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -835,6 +835,25 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
+"@meeshkanml/json-schema-faker@^0.0.0":
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/@meeshkanml/json-schema-faker/-/json-schema-faker-0.0.0.tgz#98b71f779470c84779b35ab2bc50384799e79dfb"
+  integrity sha512-Jr1tV632neWm88/Axi8W3onhhWdhD40N1cbL2LZq6UnnhKOtkT6to78/pWscI244nYMsb+ka9DrwWKoqWes3BA==
+  dependencies:
+    "@meeshkanml/json-schema-ref-parser" "0.0.0"
+    jsonpath-plus "^1.0.0"
+    randexp "^0.5.3"
+
+"@meeshkanml/json-schema-ref-parser@0.0.0":
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/@meeshkanml/json-schema-ref-parser/-/json-schema-ref-parser-0.0.0.tgz#8f61abb7a191674285bc516096bf3aca6c0c8403"
+  integrity sha512-NI+0dbUzllLPHVS5rbF9e7qUp9pbkbHn5uMAHmBy43CvGD5EfkTQTRjBB2wE5lSv5eLXICVNC4sZGPU9vLTt5g==
+  dependencies:
+    call-me-maybe "^1.0.1"
+    js-yaml "^3.13.1"
+    ono "^5.1.0"
+    url "^0.11.0"
+
 "@meeshkanml/jsonschema@^0.0.1":
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/@meeshkanml/jsonschema/-/jsonschema-0.0.1.tgz#989ff388c54785708701001e1be43bcfe7bd5e8f"
@@ -3022,11 +3041,6 @@ form-data@~2.3.2:
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
 
-format-util@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/format-util/-/format-util-1.0.3.tgz#032dca4a116262a12c43f4c3ec8566416c5b2d95"
-  integrity sha1-Ay3KShFiYqEsQ/TD7IVmQWxbLZU=
-
 fp-ts@^1.0.0:
   version "1.19.5"
   resolved "https://registry.yarnpkg.com/fp-ts/-/fp-ts-1.19.5.tgz#3da865e585dfa1fdfd51785417357ac50afc520a"
@@ -4114,7 +4128,7 @@ jetifier@^1.6.2:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@^3.12.1, js-yaml@^3.13.1:
+js-yaml@^3.13.1:
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
   integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
@@ -4200,15 +4214,6 @@ json-schema-deref-sync@^0.10.1:
     traverse "~0.6.6"
     valid-url "~1.0.9"
 
-json-schema-faker@^0.5.0-rc17:
-  version "0.5.0-rc23"
-  resolved "https://registry.yarnpkg.com/json-schema-faker/-/json-schema-faker-0.5.0-rc23.tgz#f6cfab390e429b1f57ac83199480439db60962fa"
-  integrity sha512-lRzFEnp55TihRzMvUBrtvTlM/aHGhCwfes0/T9bN9OiB2n36/SUFxtMn7anYoES+f95eU3viJ/foXKosCwsiJw==
-  dependencies:
-    json-schema-ref-parser "^6.1.0"
-    jsonpath-plus "^1.0.0"
-    randexp "^0.5.3"
-
 json-schema-poet@0.0.9:
   version "0.0.9"
   resolved "https://registry.yarnpkg.com/json-schema-poet/-/json-schema-poet-0.0.9.tgz#086d0612edd95e8657edc54f27699f04b0e5ef37"
@@ -4217,15 +4222,6 @@ json-schema-poet@0.0.9:
     fp-ts "^2.0.5"
     io-ts "^2.0.1"
     json-schema-strictly-typed "^0.0.14"
-
-json-schema-ref-parser@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/json-schema-ref-parser/-/json-schema-ref-parser-6.1.0.tgz#30af34aeab5bee0431da805dac0eb21b574bf63d"
-  integrity sha512-pXe9H1m6IgIpXmE5JSb8epilNTGsmTb2iPohAXpOdhqGFbQjNeHHsZxU+C8w6T81GZxSPFLeUoqDJmzxx5IGuw==
-  dependencies:
-    call-me-maybe "^1.0.1"
-    js-yaml "^3.12.1"
-    ono "^4.0.11"
 
 json-schema-strictly-typed@0.0.14, json-schema-strictly-typed@^0.0.14:
   version "0.0.14"
@@ -5341,12 +5337,10 @@ onetime@^2.0.0:
   dependencies:
     mimic-fn "^1.0.0"
 
-ono@^4.0.11:
-  version "4.0.11"
-  resolved "https://registry.yarnpkg.com/ono/-/ono-4.0.11.tgz#c7f4209b3e396e8a44ef43b9cedc7f5d791d221d"
-  integrity sha512-jQ31cORBFE6td25deYeD80wxKBMj+zBmHTrVxnc6CKhx8gho6ipmWM5zj/oeoqioZ99yqBls9Z/9Nss7J26G2g==
-  dependencies:
-    format-util "^1.0.3"
+ono@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/ono/-/ono-5.1.0.tgz#8cafa7e56afa2211ad63dd2eb798427e64f1a070"
+  integrity sha512-GgqRIUWErLX4l9Up0khRtbrlH8Fyj59A0nKv8V6pWEto38aUgnOGOOF7UmgFFLzFnDSc8REzaTXOc0hqEe7yIw==
 
 open@^6.2.0:
   version "6.4.0"
@@ -5727,6 +5721,11 @@ pump@^3.0.0:
     end-of-stream "^1.1.0"
     once "^1.3.1"
 
+punycode@1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
+  integrity sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=
+
 punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
@@ -5750,6 +5749,11 @@ query-string@^6.8.3:
     decode-uri-component "^0.2.0"
     split-on-first "^1.0.0"
     strict-uri-encode "^2.0.0"
+
+querystring@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
+  integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
 
 querystringify@^2.1.1:
   version "2.1.1"
@@ -7047,8 +7051,8 @@ universalify@^0.1.0:
   version "0.3.8"
   dependencies:
     buffer "^5.4.3"
-    unmock-core "file:../../../Library/Caches/Yarn/v4/npm-unmock-browser-0.3.8-06532075-607e-44f2-adff-5a3ae1c516de-1576495217213/node_modules/unmock-core"
-    unmock-fetch "file:../../../Library/Caches/Yarn/v4/npm-unmock-browser-0.3.8-06532075-607e-44f2-adff-5a3ae1c516de-1576495217213/node_modules/unmock-fetch"
+    unmock-core "file:../../../Library/Caches/Yarn/v4/npm-unmock-browser-0.3.8-4b51eb75-3a39-43a5-a0c5-b95add3e1546-1576567727104/node_modules/unmock-core"
+    unmock-fetch "file:../../../Library/Caches/Yarn/v4/npm-unmock-browser-0.3.8-4b51eb75-3a39-43a5-a0c5-b95add3e1546-1576567727104/node_modules/unmock-fetch"
 
 "unmock-cli@file:../unmock-js/packages/unmock-cli":
   version "0.3.10"
@@ -7058,12 +7062,13 @@ universalify@^0.1.0:
     commander "^2.20.0"
     glob "^7.1.3"
     readline-sync "^1.4.10"
-    unmock-core "file:../../../Library/Caches/Yarn/v4/npm-unmock-cli-0.3.10-a75a837d-ba86-4c2f-a5e6-a31538968c9f-1576495217173/node_modules/unmock-core"
-    unmock-node "file:../../../Library/Caches/Yarn/v4/npm-unmock-cli-0.3.10-a75a837d-ba86-4c2f-a5e6-a31538968c9f-1576495217173/node_modules/unmock-node"
+    unmock-core "file:../../../Library/Caches/Yarn/v4/npm-unmock-cli-0.3.10-a389e0bc-0c12-4977-9c11-0a62add12029-1576567727105/node_modules/unmock-core"
+    unmock-node "file:../../../Library/Caches/Yarn/v4/npm-unmock-cli-0.3.10-a389e0bc-0c12-4977-9c11-0a62add12029-1576567727105/node_modules/unmock-node"
 
 "unmock-core@file:../unmock-js/packages/unmock-core":
   version "0.3.10"
   dependencies:
+    "@meeshkanml/json-schema-faker" "^0.0.0"
     "@meeshkanml/jsonschema" "^0.0.1"
     "@types/sinon" "^7.0.13"
     "@types/whatwg-url" "^6.4.0"
@@ -7078,14 +7083,13 @@ universalify@^0.1.0:
     io-ts "^2.0.1"
     json-pointer "^0.6.0"
     json-schema-deref-sync "^0.10.1"
-    json-schema-faker "^0.5.0-rc17"
     json-schema-poet "0.0.9"
     json-schema-strictly-typed "0.0.14"
     loas3 "^0.1.4"
     lodash "^4.17.14"
     minimatch "^3.0.4"
     monocle-ts "^2.0.0"
-    openapi-refinements "file:../../../Library/Caches/Yarn/v4/npm-unmock-core-0.3.10-6150f9b5-d4c9-4694-973b-822dd49ef8e9-1576495217188/node_modules/openapi-refinements"
+    openapi-refinements "file:../../../Library/Caches/Yarn/v4/npm-unmock-core-0.3.10-03d578d5-8d3a-4522-89cd-d64fcbcae442-1576567727107/node_modules/openapi-refinements"
     query-string "^6.8.3"
     seedrandom "^3.0.3"
     sinon "^7.4.1"
@@ -7100,7 +7104,7 @@ universalify@^0.1.0:
     "@types/url-parse" "^1.4.3"
     cross-fetch "^3.0.4"
     debug "^4.1.1"
-    unmock-core "file:../../../Library/Caches/Yarn/v4/npm-unmock-fetch-0.3.10-a627f727-7744-4b72-894c-50c8d86a440d-1576495217218/node_modules/unmock-core"
+    unmock-core "file:../../../Library/Caches/Yarn/v4/npm-unmock-fetch-0.3.10-d2fbe2a6-9ee7-48f8-b967-99980d991e10-1576567727189/node_modules/unmock-core"
     url-parse "^1.4.7"
 
 "unmock-node@file:../unmock-js/packages/unmock-node":
@@ -7117,17 +7121,17 @@ universalify@^0.1.0:
     node-fetch "^2.6.0"
     readable-stream "^3.4.0"
     shimmer "^1.2.1"
-    unmock-core "file:../../../Library/Caches/Yarn/v4/npm-unmock-node-0.3.10-da5e48b0-c12e-40f7-b81f-61b59dd83894-1576495217175/node_modules/unmock-core"
+    unmock-core "file:../../../Library/Caches/Yarn/v4/npm-unmock-node-0.3.10-f79407ab-3242-455c-870c-6eeaf4038c25-1576567727092/node_modules/unmock-core"
     uuid "^3.3.2"
     winston "^3.2.1"
 
 "unmock@file:../unmock-js/packages/unmock":
   version "0.3.10"
   dependencies:
-    unmock-browser "file:../../../Library/Caches/Yarn/v4/npm-unmock-0.3.10-fdafe0fe-cfce-464a-b06a-3391f68efc02-1576495217169/node_modules/unmock-browser"
-    unmock-cli "file:../../../Library/Caches/Yarn/v4/npm-unmock-0.3.10-fdafe0fe-cfce-464a-b06a-3391f68efc02-1576495217169/node_modules/unmock-cli"
-    unmock-core "file:../../../Library/Caches/Yarn/v4/npm-unmock-0.3.10-fdafe0fe-cfce-464a-b06a-3391f68efc02-1576495217169/node_modules/unmock-core"
-    unmock-node "file:../../../Library/Caches/Yarn/v4/npm-unmock-0.3.10-fdafe0fe-cfce-464a-b06a-3391f68efc02-1576495217169/node_modules/unmock-node"
+    unmock-browser "file:../../../Library/Caches/Yarn/v4/npm-unmock-0.3.10-ed90b6de-13bb-414e-a841-cdff9ec31026-1576567727088/node_modules/unmock-browser"
+    unmock-cli "file:../../../Library/Caches/Yarn/v4/npm-unmock-0.3.10-ed90b6de-13bb-414e-a841-cdff9ec31026-1576567727088/node_modules/unmock-cli"
+    unmock-core "file:../../../Library/Caches/Yarn/v4/npm-unmock-0.3.10-ed90b6de-13bb-414e-a841-cdff9ec31026-1576567727088/node_modules/unmock-core"
+    unmock-node "file:../../../Library/Caches/Yarn/v4/npm-unmock-0.3.10-ed90b6de-13bb-414e-a841-cdff9ec31026-1576567727088/node_modules/unmock-node"
 
 unpipe@~1.0.0:
   version "1.0.0"
@@ -7161,6 +7165,14 @@ url-parse@^1.4.7:
   dependencies:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
+
+url@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/url/-/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1"
+  integrity sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=
+  dependencies:
+    punycode "1.3.2"
+    querystring "0.2.0"
 
 use@^3.1.0:
   version "3.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5349,8 +5349,10 @@ open@^6.2.0:
   dependencies:
     is-wsl "^1.1.0"
 
-"openapi-refinements@file:../unmock-js/packages/openapi-refinements":
-  version "0.3.10"
+openapi-refinements@^0.3.11:
+  version "0.3.11"
+  resolved "https://registry.yarnpkg.com/openapi-refinements/-/openapi-refinements-0.3.11.tgz#670f3998943e91ff8ff5960a395219a68073739e"
+  integrity sha512-yo6Rcr+vHg52AtwSwva3YmZcFlNz5srKDFN57aSYtuteopPJWarfX3FMvQGJ2rFhzm8hyruLHVX5p/ufH61Z7g==
   dependencies:
     "@meeshkanml/jsonschema" "^0.0.1"
 
@@ -7047,26 +7049,32 @@ universalify@^0.1.0:
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
   integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
 
-"unmock-browser@file:../unmock-js/packages/unmock-browser":
-  version "0.3.8"
+unmock-browser@^0.3.11:
+  version "0.3.11"
+  resolved "https://registry.yarnpkg.com/unmock-browser/-/unmock-browser-0.3.11.tgz#8c36c55a798a968ff99e56f8d884c1e6913f3c72"
+  integrity sha512-0aGmxypUJItsZ8kuYYiTnIEinRCoNVM6l78rmqqi22IyhH3SpNbwcW2xl9HqE7OTyOjM8gIMyPh5AbCrkd5zOw==
   dependencies:
     buffer "^5.4.3"
-    unmock-core "file:../../../Library/Caches/Yarn/v4/npm-unmock-browser-0.3.8-d68efdfd-1552-4f83-909b-7c29fc1bd7cb-1576579534603/node_modules/unmock-core"
-    unmock-fetch "file:../../../Library/Caches/Yarn/v4/npm-unmock-browser-0.3.8-d68efdfd-1552-4f83-909b-7c29fc1bd7cb-1576579534603/node_modules/unmock-fetch"
+    unmock-core "^0.3.11"
+    unmock-fetch "^0.3.11"
 
-"unmock-cli@file:../unmock-js/packages/unmock-cli":
-  version "0.3.10"
+unmock-cli@^0.3.11:
+  version "0.3.11"
+  resolved "https://registry.yarnpkg.com/unmock-cli/-/unmock-cli-0.3.11.tgz#0369db2c07634b714b8c6e5ca5f9de79ae18b9d7"
+  integrity sha512-sr2DZmu0JrAFT7U0bTxebqTFe5oIAHYoFHa4ermhGYRMe6SJg8a/vL8JhCGxWYEgXwxGQCC9Ejy5UOzfjnwYxw==
   dependencies:
     "@types/readline-sync" "^1.4.3"
     chalk "^2.4.2"
     commander "^2.20.0"
     glob "^7.1.3"
     readline-sync "^1.4.10"
-    unmock-core "file:../../../Library/Caches/Yarn/v4/npm-unmock-cli-0.3.10-0d9410cc-a75b-4a08-a02f-29ee3c5c525e-1576579534700/node_modules/unmock-core"
-    unmock-node "file:../../../Library/Caches/Yarn/v4/npm-unmock-cli-0.3.10-0d9410cc-a75b-4a08-a02f-29ee3c5c525e-1576579534700/node_modules/unmock-node"
+    unmock-core "^0.3.11"
+    unmock-node "^0.3.11"
 
-"unmock-core@file:../unmock-js/packages/unmock-core":
-  version "0.3.10"
+unmock-core@^0.3.11:
+  version "0.3.11"
+  resolved "https://registry.yarnpkg.com/unmock-core/-/unmock-core-0.3.11.tgz#a66e95e2ef872920e68ae7f3da60f3b9b6ee9716"
+  integrity sha512-rADXslsxpiopsIAKUMbRWM5vRuYWVgMT9+WW0l+yqqtwMdHSgsTO+7ee+qW9ez2Ha+wfsEuC+Ve28WJKNs3frQ==
   dependencies:
     "@meeshkanml/json-schema-faker" "^0.0.2"
     "@meeshkanml/jsonschema" "^0.0.1"
@@ -7089,7 +7097,7 @@ universalify@^0.1.0:
     lodash "^4.17.14"
     minimatch "^3.0.4"
     monocle-ts "^2.0.0"
-    openapi-refinements "file:../../../Library/Caches/Yarn/v4/npm-unmock-core-0.3.10-413cdd79-c270-4995-b4ed-1502c27d522e-1576579534605/node_modules/openapi-refinements"
+    openapi-refinements "^0.3.11"
     query-string "^6.8.3"
     seedrandom "^3.0.3"
     sinon "^7.4.1"
@@ -7097,18 +7105,22 @@ universalify@^0.1.0:
     whatwg-url "^7.0.0"
     winston "^3.2.1"
 
-"unmock-fetch@file:../unmock-js/packages/unmock-fetch":
-  version "0.3.10"
+unmock-fetch@^0.3.11:
+  version "0.3.11"
+  resolved "https://registry.yarnpkg.com/unmock-fetch/-/unmock-fetch-0.3.11.tgz#30d14ae5eb6463a288aa526401c477b45a2df65f"
+  integrity sha512-/7CIBc5s1o46jP0GxCH7qzdi2I+T+VWJqX3z1dHCsdV2wfumE2pyTQEr5edxGMLP7tu6ON9xcfjt7wifkD+Fog==
   dependencies:
     "@types/debug" "^4.1.5"
     "@types/url-parse" "^1.4.3"
     cross-fetch "^3.0.4"
     debug "^4.1.1"
-    unmock-core "file:../../../Library/Caches/Yarn/v4/npm-unmock-fetch-0.3.10-1c396fb2-27e9-4a83-962d-929f9fa99a57-1576579534706/node_modules/unmock-core"
+    unmock-core "^0.3.11"
     url-parse "^1.4.7"
 
-"unmock-node@file:../unmock-js/packages/unmock-node":
-  version "0.3.10"
+unmock-node@^0.3.11:
+  version "0.3.11"
+  resolved "https://registry.yarnpkg.com/unmock-node/-/unmock-node-0.3.11.tgz#123f16bfca4b329ec05db43abb16ebcfd1898bcd"
+  integrity sha512-Q8/i686Wm5j+L6qNyd5ljjYWOyagbNHGzrnsJWzv3R3UCdb0mEvYlsrsjkrJo3SjZlG48Jrflhbb5maCxak3JA==
   dependencies:
     "@types/node" "^12.7.8"
     "@types/node-fetch" "^2.5.2"
@@ -7121,17 +7133,19 @@ universalify@^0.1.0:
     node-fetch "^2.6.0"
     readable-stream "^3.4.0"
     shimmer "^1.2.1"
-    unmock-core "file:../../../Library/Caches/Yarn/v4/npm-unmock-node-0.3.10-27974677-ad33-4b62-b7ea-e2b63f3d0541-1576579534701/node_modules/unmock-core"
+    unmock-core "^0.3.11"
     uuid "^3.3.2"
     winston "^3.2.1"
 
-"unmock@file:../unmock-js/packages/unmock":
-  version "0.3.10"
+unmock@^0.3.11:
+  version "0.3.11"
+  resolved "https://registry.yarnpkg.com/unmock/-/unmock-0.3.11.tgz#8972ad676877d375cc209c2ab828d1daa11fb017"
+  integrity sha512-lTKnrJh4Lvyu+xrAZCqaKcWw2IDk7VtsM2PhOkUAzHIoUTYykZ9QU1ol77CIvKKDE6XHrUiu/QJWYMWK9/IIgQ==
   dependencies:
-    unmock-browser "file:../../../Library/Caches/Yarn/v4/npm-unmock-0.3.10-cc7e036c-6cab-4024-92ce-4d39585616b8-1576579534599/node_modules/unmock-browser"
-    unmock-cli "file:../../../Library/Caches/Yarn/v4/npm-unmock-0.3.10-cc7e036c-6cab-4024-92ce-4d39585616b8-1576579534599/node_modules/unmock-cli"
-    unmock-core "file:../../../Library/Caches/Yarn/v4/npm-unmock-0.3.10-cc7e036c-6cab-4024-92ce-4d39585616b8-1576579534599/node_modules/unmock-core"
-    unmock-node "file:../../../Library/Caches/Yarn/v4/npm-unmock-0.3.10-cc7e036c-6cab-4024-92ce-4d39585616b8-1576579534599/node_modules/unmock-node"
+    unmock-browser "^0.3.11"
+    unmock-cli "^0.3.11"
+    unmock-core "^0.3.11"
+    unmock-node "^0.3.11"
 
 unpipe@~1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -835,10 +835,10 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
-"@meeshkanml/json-schema-faker@^0.0.1":
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/@meeshkanml/json-schema-faker/-/json-schema-faker-0.0.1.tgz#67c57a1cfd682667a0e2e52fbb28b8c2ceec1356"
-  integrity sha512-KFVv4udZITeR97+9SnkWXZLR/7TKV3bS5A6hAc5UUH2WFv+MQDKbib77Le9Btdnkdk7IwbOa9KrBJXIZb/aKSw==
+"@meeshkanml/json-schema-faker@^0.0.2":
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/@meeshkanml/json-schema-faker/-/json-schema-faker-0.0.2.tgz#2c46931038cea6fd8c710d3d9808e7eec1a72638"
+  integrity sha512-NyuW1hD6W2eHMN58vDpYiRGkZKQaZN/nZyYa5Z6j2ajp3vHlDpDPYGOldAdi7tIxH9QNFUgvRadoUBfgNIv+0w==
   dependencies:
     "@meeshkanml/json-schema-ref-parser" "0.0.0"
     jsonpath-plus "^1.0.0"
@@ -7051,8 +7051,8 @@ universalify@^0.1.0:
   version "0.3.8"
   dependencies:
     buffer "^5.4.3"
-    unmock-core "file:../../../Library/Caches/Yarn/v4/npm-unmock-browser-0.3.8-45bae694-9c87-4840-8f5e-4c9a275a2a86-1576570282984/node_modules/unmock-core"
-    unmock-fetch "file:../../../Library/Caches/Yarn/v4/npm-unmock-browser-0.3.8-45bae694-9c87-4840-8f5e-4c9a275a2a86-1576570282984/node_modules/unmock-fetch"
+    unmock-core "file:../../../Library/Caches/Yarn/v4/npm-unmock-browser-0.3.8-d68efdfd-1552-4f83-909b-7c29fc1bd7cb-1576579534603/node_modules/unmock-core"
+    unmock-fetch "file:../../../Library/Caches/Yarn/v4/npm-unmock-browser-0.3.8-d68efdfd-1552-4f83-909b-7c29fc1bd7cb-1576579534603/node_modules/unmock-fetch"
 
 "unmock-cli@file:../unmock-js/packages/unmock-cli":
   version "0.3.10"
@@ -7062,13 +7062,13 @@ universalify@^0.1.0:
     commander "^2.20.0"
     glob "^7.1.3"
     readline-sync "^1.4.10"
-    unmock-core "file:../../../Library/Caches/Yarn/v4/npm-unmock-cli-0.3.10-882d2023-4aa0-4c31-b17f-e5f43439a56b-1576570282922/node_modules/unmock-core"
-    unmock-node "file:../../../Library/Caches/Yarn/v4/npm-unmock-cli-0.3.10-882d2023-4aa0-4c31-b17f-e5f43439a56b-1576570282922/node_modules/unmock-node"
+    unmock-core "file:../../../Library/Caches/Yarn/v4/npm-unmock-cli-0.3.10-0d9410cc-a75b-4a08-a02f-29ee3c5c525e-1576579534700/node_modules/unmock-core"
+    unmock-node "file:../../../Library/Caches/Yarn/v4/npm-unmock-cli-0.3.10-0d9410cc-a75b-4a08-a02f-29ee3c5c525e-1576579534700/node_modules/unmock-node"
 
 "unmock-core@file:../unmock-js/packages/unmock-core":
   version "0.3.10"
   dependencies:
-    "@meeshkanml/json-schema-faker" "^0.0.1"
+    "@meeshkanml/json-schema-faker" "^0.0.2"
     "@meeshkanml/jsonschema" "^0.0.1"
     "@types/sinon" "^7.0.13"
     "@types/whatwg-url" "^6.4.0"
@@ -7089,7 +7089,7 @@ universalify@^0.1.0:
     lodash "^4.17.14"
     minimatch "^3.0.4"
     monocle-ts "^2.0.0"
-    openapi-refinements "file:../../../Library/Caches/Yarn/v4/npm-unmock-core-0.3.10-172a600f-38e3-4ee7-97be-2ef950bf6d58-1576570282924/node_modules/openapi-refinements"
+    openapi-refinements "file:../../../Library/Caches/Yarn/v4/npm-unmock-core-0.3.10-413cdd79-c270-4995-b4ed-1502c27d522e-1576579534605/node_modules/openapi-refinements"
     query-string "^6.8.3"
     seedrandom "^3.0.3"
     sinon "^7.4.1"
@@ -7104,7 +7104,7 @@ universalify@^0.1.0:
     "@types/url-parse" "^1.4.3"
     cross-fetch "^3.0.4"
     debug "^4.1.1"
-    unmock-core "file:../../../Library/Caches/Yarn/v4/npm-unmock-fetch-0.3.10-8177c7f0-242f-4c36-b69d-9d63ad35f9d9-1576570283003/node_modules/unmock-core"
+    unmock-core "file:../../../Library/Caches/Yarn/v4/npm-unmock-fetch-0.3.10-1c396fb2-27e9-4a83-962d-929f9fa99a57-1576579534706/node_modules/unmock-core"
     url-parse "^1.4.7"
 
 "unmock-node@file:../unmock-js/packages/unmock-node":
@@ -7121,17 +7121,17 @@ universalify@^0.1.0:
     node-fetch "^2.6.0"
     readable-stream "^3.4.0"
     shimmer "^1.2.1"
-    unmock-core "file:../../../Library/Caches/Yarn/v4/npm-unmock-node-0.3.10-d0fc262a-78c5-4021-968c-83c076a9e1e5-1576570282909/node_modules/unmock-core"
+    unmock-core "file:../../../Library/Caches/Yarn/v4/npm-unmock-node-0.3.10-27974677-ad33-4b62-b7ea-e2b63f3d0541-1576579534701/node_modules/unmock-core"
     uuid "^3.3.2"
     winston "^3.2.1"
 
 "unmock@file:../unmock-js/packages/unmock":
   version "0.3.10"
   dependencies:
-    unmock-browser "file:../../../Library/Caches/Yarn/v4/npm-unmock-0.3.10-86643492-6742-464d-8be4-bc83668a4a9d-1576570282904/node_modules/unmock-browser"
-    unmock-cli "file:../../../Library/Caches/Yarn/v4/npm-unmock-0.3.10-86643492-6742-464d-8be4-bc83668a4a9d-1576570282904/node_modules/unmock-cli"
-    unmock-core "file:../../../Library/Caches/Yarn/v4/npm-unmock-0.3.10-86643492-6742-464d-8be4-bc83668a4a9d-1576570282904/node_modules/unmock-core"
-    unmock-node "file:../../../Library/Caches/Yarn/v4/npm-unmock-0.3.10-86643492-6742-464d-8be4-bc83668a4a9d-1576570282904/node_modules/unmock-node"
+    unmock-browser "file:../../../Library/Caches/Yarn/v4/npm-unmock-0.3.10-cc7e036c-6cab-4024-92ce-4d39585616b8-1576579534599/node_modules/unmock-browser"
+    unmock-cli "file:../../../Library/Caches/Yarn/v4/npm-unmock-0.3.10-cc7e036c-6cab-4024-92ce-4d39585616b8-1576579534599/node_modules/unmock-cli"
+    unmock-core "file:../../../Library/Caches/Yarn/v4/npm-unmock-0.3.10-cc7e036c-6cab-4024-92ce-4d39585616b8-1576579534599/node_modules/unmock-core"
+    unmock-node "file:../../../Library/Caches/Yarn/v4/npm-unmock-0.3.10-cc7e036c-6cab-4024-92ce-4d39585616b8-1576579534599/node_modules/unmock-node"
 
 unpipe@~1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5727,11 +5727,6 @@ pump@^3.0.0:
     end-of-stream "^1.1.0"
     once "^1.3.1"
 
-punycode@1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
-  integrity sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=
-
 punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
@@ -5755,11 +5750,6 @@ query-string@^6.8.3:
     decode-uri-component "^0.2.0"
     split-on-first "^1.0.0"
     strict-uri-encode "^2.0.0"
-
-querystring@0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
-  integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
 
 querystringify@^2.1.1:
   version "2.1.1"
@@ -7056,8 +7046,8 @@ universalify@^0.1.0:
 "unmock-browser@file:../unmock-js/packages/unmock-browser":
   version "0.3.8"
   dependencies:
-    unmock-core "file:../../../Library/Caches/Yarn/v4/npm-unmock-browser-0.3.8-e1348f2d-7d68-4838-b13a-a86e74598369-1576483377129/node_modules/unmock-core"
-    unmock-fetch "file:../../../Library/Caches/Yarn/v4/npm-unmock-browser-0.3.8-e1348f2d-7d68-4838-b13a-a86e74598369-1576483377129/node_modules/unmock-fetch"
+    unmock-core "file:../../../Library/Caches/Yarn/v4/npm-unmock-browser-0.3.8-8e4b0edd-1b2d-4213-8598-2ddb16217993-1576484572075/node_modules/unmock-core"
+    unmock-fetch "file:../../../Library/Caches/Yarn/v4/npm-unmock-browser-0.3.8-8e4b0edd-1b2d-4213-8598-2ddb16217993-1576484572075/node_modules/unmock-fetch"
 
 "unmock-cli@file:../unmock-js/packages/unmock-cli":
   version "0.3.10"
@@ -7067,8 +7057,8 @@ universalify@^0.1.0:
     commander "^2.20.0"
     glob "^7.1.3"
     readline-sync "^1.4.10"
-    unmock-core "file:../../../Library/Caches/Yarn/v4/npm-unmock-cli-0.3.10-7f6e61ab-021d-4191-aa51-fe3008197d6c-1576483377130/node_modules/unmock-core"
-    unmock-node "file:../../../Library/Caches/Yarn/v4/npm-unmock-cli-0.3.10-7f6e61ab-021d-4191-aa51-fe3008197d6c-1576483377130/node_modules/unmock-node"
+    unmock-core "file:../../../Library/Caches/Yarn/v4/npm-unmock-cli-0.3.10-198a8238-7296-4008-ba04-43eaae13e13a-1576484572073/node_modules/unmock-core"
+    unmock-node "file:../../../Library/Caches/Yarn/v4/npm-unmock-cli-0.3.10-198a8238-7296-4008-ba04-43eaae13e13a-1576484572073/node_modules/unmock-node"
 
 "unmock-core@file:../unmock-js/packages/unmock-core":
   version "0.3.10"
@@ -7094,7 +7084,7 @@ universalify@^0.1.0:
     lodash "^4.17.14"
     minimatch "^3.0.4"
     monocle-ts "^2.0.0"
-    openapi-refinements "file:../../../Library/Caches/Yarn/v4/npm-unmock-core-0.3.10-39690c4f-ebce-491e-9a27-172c80e16dbb-1576483377144/node_modules/openapi-refinements"
+    openapi-refinements "file:../../../Library/Caches/Yarn/v4/npm-unmock-core-0.3.10-8176f220-92e3-418f-bffd-3592c6236149-1576484572076/node_modules/openapi-refinements"
     query-string "^6.8.3"
     seedrandom "^3.0.3"
     sinon "^7.4.1"
@@ -7109,7 +7099,7 @@ universalify@^0.1.0:
     "@types/url-parse" "^1.4.3"
     cross-fetch "^3.0.4"
     debug "^4.1.1"
-    unmock-core "file:../../../Library/Caches/Yarn/v4/npm-unmock-fetch-0.3.10-8f40124c-5b35-484c-87d7-947ee24414e3-1576483377173/node_modules/unmock-core"
+    unmock-core "file:../../../Library/Caches/Yarn/v4/npm-unmock-fetch-0.3.10-38ffe2b2-9a19-4f1a-bc03-0e7d35781fab-1576484572109/node_modules/unmock-core"
     url-parse "^1.4.7"
 
 "unmock-node@file:../unmock-js/packages/unmock-node":
@@ -7126,17 +7116,17 @@ universalify@^0.1.0:
     node-fetch "^2.6.0"
     readable-stream "^3.4.0"
     shimmer "^1.2.1"
-    unmock-core "file:../../../Library/Caches/Yarn/v4/npm-unmock-node-0.3.10-f92d11a8-f054-459b-89ae-c366c4781872-1576483377132/node_modules/unmock-core"
+    unmock-core "file:../../../Library/Caches/Yarn/v4/npm-unmock-node-0.3.10-3b5c27b8-1e86-4d11-ba4a-57468cc73f84-1576484572060/node_modules/unmock-core"
     uuid "^3.3.2"
     winston "^3.2.1"
 
 "unmock@file:../unmock-js/packages/unmock":
   version "0.3.10"
   dependencies:
-    unmock-browser "file:../../../Library/Caches/Yarn/v4/npm-unmock-0.3.10-88a8c1e3-d965-439d-87af-3f8b7b7fc456-1576483377124/node_modules/unmock-browser"
-    unmock-cli "file:../../../Library/Caches/Yarn/v4/npm-unmock-0.3.10-88a8c1e3-d965-439d-87af-3f8b7b7fc456-1576483377124/node_modules/unmock-cli"
-    unmock-core "file:../../../Library/Caches/Yarn/v4/npm-unmock-0.3.10-88a8c1e3-d965-439d-87af-3f8b7b7fc456-1576483377124/node_modules/unmock-core"
-    unmock-node "file:../../../Library/Caches/Yarn/v4/npm-unmock-0.3.10-88a8c1e3-d965-439d-87af-3f8b7b7fc456-1576483377124/node_modules/unmock-node"
+    unmock-browser "file:../../../Library/Caches/Yarn/v4/npm-unmock-0.3.10-b42cc04d-e31b-4e02-abb4-b844cf00d3ad-1576484572056/node_modules/unmock-browser"
+    unmock-cli "file:../../../Library/Caches/Yarn/v4/npm-unmock-0.3.10-b42cc04d-e31b-4e02-abb4-b844cf00d3ad-1576484572056/node_modules/unmock-cli"
+    unmock-core "file:../../../Library/Caches/Yarn/v4/npm-unmock-0.3.10-b42cc04d-e31b-4e02-abb4-b844cf00d3ad-1576484572056/node_modules/unmock-core"
+    unmock-node "file:../../../Library/Caches/Yarn/v4/npm-unmock-0.3.10-b42cc04d-e31b-4e02-abb4-b844cf00d3ad-1576484572056/node_modules/unmock-node"
 
 unpipe@~1.0.0:
   version "1.0.0"
@@ -7170,14 +7160,6 @@ url-parse@^1.4.7:
   dependencies:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
-
-url@^0.11.0:
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/url/-/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1"
-  integrity sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=
-  dependencies:
-    punycode "1.3.2"
-    querystring "0.2.0"
 
 use@^3.1.0:
   version "3.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7046,8 +7046,9 @@ universalify@^0.1.0:
 "unmock-browser@file:../unmock-js/packages/unmock-browser":
   version "0.3.8"
   dependencies:
-    unmock-core "file:../../../Library/Caches/Yarn/v4/npm-unmock-browser-0.3.8-8e4b0edd-1b2d-4213-8598-2ddb16217993-1576484572075/node_modules/unmock-core"
-    unmock-fetch "file:../../../Library/Caches/Yarn/v4/npm-unmock-browser-0.3.8-8e4b0edd-1b2d-4213-8598-2ddb16217993-1576484572075/node_modules/unmock-fetch"
+    buffer "^5.4.3"
+    unmock-core "file:../../../Library/Caches/Yarn/v4/npm-unmock-browser-0.3.8-06532075-607e-44f2-adff-5a3ae1c516de-1576495217213/node_modules/unmock-core"
+    unmock-fetch "file:../../../Library/Caches/Yarn/v4/npm-unmock-browser-0.3.8-06532075-607e-44f2-adff-5a3ae1c516de-1576495217213/node_modules/unmock-fetch"
 
 "unmock-cli@file:../unmock-js/packages/unmock-cli":
   version "0.3.10"
@@ -7057,8 +7058,8 @@ universalify@^0.1.0:
     commander "^2.20.0"
     glob "^7.1.3"
     readline-sync "^1.4.10"
-    unmock-core "file:../../../Library/Caches/Yarn/v4/npm-unmock-cli-0.3.10-198a8238-7296-4008-ba04-43eaae13e13a-1576484572073/node_modules/unmock-core"
-    unmock-node "file:../../../Library/Caches/Yarn/v4/npm-unmock-cli-0.3.10-198a8238-7296-4008-ba04-43eaae13e13a-1576484572073/node_modules/unmock-node"
+    unmock-core "file:../../../Library/Caches/Yarn/v4/npm-unmock-cli-0.3.10-a75a837d-ba86-4c2f-a5e6-a31538968c9f-1576495217173/node_modules/unmock-core"
+    unmock-node "file:../../../Library/Caches/Yarn/v4/npm-unmock-cli-0.3.10-a75a837d-ba86-4c2f-a5e6-a31538968c9f-1576495217173/node_modules/unmock-node"
 
 "unmock-core@file:../unmock-js/packages/unmock-core":
   version "0.3.10"
@@ -7084,7 +7085,7 @@ universalify@^0.1.0:
     lodash "^4.17.14"
     minimatch "^3.0.4"
     monocle-ts "^2.0.0"
-    openapi-refinements "file:../../../Library/Caches/Yarn/v4/npm-unmock-core-0.3.10-8176f220-92e3-418f-bffd-3592c6236149-1576484572076/node_modules/openapi-refinements"
+    openapi-refinements "file:../../../Library/Caches/Yarn/v4/npm-unmock-core-0.3.10-6150f9b5-d4c9-4694-973b-822dd49ef8e9-1576495217188/node_modules/openapi-refinements"
     query-string "^6.8.3"
     seedrandom "^3.0.3"
     sinon "^7.4.1"
@@ -7099,7 +7100,7 @@ universalify@^0.1.0:
     "@types/url-parse" "^1.4.3"
     cross-fetch "^3.0.4"
     debug "^4.1.1"
-    unmock-core "file:../../../Library/Caches/Yarn/v4/npm-unmock-fetch-0.3.10-38ffe2b2-9a19-4f1a-bc03-0e7d35781fab-1576484572109/node_modules/unmock-core"
+    unmock-core "file:../../../Library/Caches/Yarn/v4/npm-unmock-fetch-0.3.10-a627f727-7744-4b72-894c-50c8d86a440d-1576495217218/node_modules/unmock-core"
     url-parse "^1.4.7"
 
 "unmock-node@file:../unmock-js/packages/unmock-node":
@@ -7116,17 +7117,17 @@ universalify@^0.1.0:
     node-fetch "^2.6.0"
     readable-stream "^3.4.0"
     shimmer "^1.2.1"
-    unmock-core "file:../../../Library/Caches/Yarn/v4/npm-unmock-node-0.3.10-3b5c27b8-1e86-4d11-ba4a-57468cc73f84-1576484572060/node_modules/unmock-core"
+    unmock-core "file:../../../Library/Caches/Yarn/v4/npm-unmock-node-0.3.10-da5e48b0-c12e-40f7-b81f-61b59dd83894-1576495217175/node_modules/unmock-core"
     uuid "^3.3.2"
     winston "^3.2.1"
 
 "unmock@file:../unmock-js/packages/unmock":
   version "0.3.10"
   dependencies:
-    unmock-browser "file:../../../Library/Caches/Yarn/v4/npm-unmock-0.3.10-b42cc04d-e31b-4e02-abb4-b844cf00d3ad-1576484572056/node_modules/unmock-browser"
-    unmock-cli "file:../../../Library/Caches/Yarn/v4/npm-unmock-0.3.10-b42cc04d-e31b-4e02-abb4-b844cf00d3ad-1576484572056/node_modules/unmock-cli"
-    unmock-core "file:../../../Library/Caches/Yarn/v4/npm-unmock-0.3.10-b42cc04d-e31b-4e02-abb4-b844cf00d3ad-1576484572056/node_modules/unmock-core"
-    unmock-node "file:../../../Library/Caches/Yarn/v4/npm-unmock-0.3.10-b42cc04d-e31b-4e02-abb4-b844cf00d3ad-1576484572056/node_modules/unmock-node"
+    unmock-browser "file:../../../Library/Caches/Yarn/v4/npm-unmock-0.3.10-fdafe0fe-cfce-464a-b06a-3391f68efc02-1576495217169/node_modules/unmock-browser"
+    unmock-cli "file:../../../Library/Caches/Yarn/v4/npm-unmock-0.3.10-fdafe0fe-cfce-464a-b06a-3391f68efc02-1576495217169/node_modules/unmock-cli"
+    unmock-core "file:../../../Library/Caches/Yarn/v4/npm-unmock-0.3.10-fdafe0fe-cfce-464a-b06a-3391f68efc02-1576495217169/node_modules/unmock-core"
+    unmock-node "file:../../../Library/Caches/Yarn/v4/npm-unmock-0.3.10-fdafe0fe-cfce-464a-b06a-3391f68efc02-1576495217169/node_modules/unmock-node"
 
 unpipe@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
- Example of using `unmock` in running on-device in React Native. In development, where `NODE_ENV==="development"`, switches on Unmock to mock the Cat Facts API.
- Uses `unmock` from `unmock-browser`: this seems to be a safer bet than using `unmock` package, because using that seems to mess things up when running a development server. `unmock-browser` _only_ overrides `global.fetch` or `window.fetch` and cannot have weird sife-effects of messing up other Node.js stuff (might be worth checking if this can be fixed by adding `react-native` field in the [package.json](https://github.com/unmock/unmock-js/blob/dev/packages/unmock/package.json#L9) of `unmock`

Tricks this required:
- ~`global.Buffer` needs to be poly-filled with `require('buffer').Buffer`:  https://github.com/facebook/react-native/issues/23922#issuecomment-476070032~ Implemented in https://github.com/unmock/unmock-js/pull/359
- ~`json-schema-ref-parser` depends on `http`, `https` and `url` so metro bundler fails building the project because `http`, `https` and `url` cannot be resolved. The manual fix is to edit `node_modules/json-schema-ref-parser/package.json` and add `http: false` and `https: false` in its `browser` field (apparently the modules are not needed by `unmock-core`). The problem with `url` can be similarly by adding `url: false` or, preferably, `"url": "whatwg-url"`~ Implemented in https://github.com/unmock/unmock-js/pull/360

Future stuff:
- Running tests in the virtual device using Unmock?
- Adding a component for switching Unmock on and off?
- Adding CircleCI integration